### PR TITLE
Add transfer ref logic when token is freezable by creator

### DIFF
--- a/token-minter/sources/properties/collection_properties.move
+++ b/token-minter/sources/properties/collection_properties.move
@@ -1,6 +1,5 @@
 module minter::collection_properties {
     use std::error;
-    use std::signer;
     use aptos_framework::object::{Self, Object};
 
     friend minter::token_minter;
@@ -28,8 +27,8 @@ module minter::collection_properties {
         mutable_token_uri: bool,
         /// Determines if the creator can burn tokens
         tokens_burnable_by_creator: bool,
-        /// Determines if the creator can freeze tokens
-        tokens_freezable_by_creator: bool,
+        /// Determines if the creator can transfer tokens
+        tokens_transferable_by_creator: bool,
         /// If the collection is soulbound
         soulbound: bool,
     }
@@ -43,7 +42,7 @@ module minter::collection_properties {
         mutable_token_properties: bool,
         mutable_token_uri: bool,
         tokens_burnable_by_creator: bool,
-        tokens_freezable_by_creator: bool,
+        tokens_transferable_by_creator: bool,
         soulbound: bool,
     ) {
         move_to(collection_signer, CollectionProperties {
@@ -54,84 +53,9 @@ module minter::collection_properties {
             mutable_token_properties,
             mutable_token_uri,
             tokens_burnable_by_creator,
-            tokens_freezable_by_creator,
+            tokens_transferable_by_creator,
             soulbound,
         });
-    }
-
-    // ================================== Setters ================================== //
-    /// Only the creator of the collection can call this function, as they only own the properties.
-
-    public entry fun set_mutable_description<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        mutable_description: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).mutable_description = mutable_description;
-    }
-
-    public entry fun set_mutable_uri<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        mutable_uri: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).mutable_uri = mutable_uri;
-    }
-
-    public entry fun set_mutable_token_description<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        mutable_token_description: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).mutable_token_description = mutable_token_description;
-    }
-
-    public entry fun set_mutable_token_name<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        mutable_token_name: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).mutable_token_name = mutable_token_name;
-    }
-
-    public entry fun set_mutable_token_properties<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        mutable_token_properties: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).mutable_token_properties = mutable_token_properties;
-    }
-
-    public entry fun set_mutable_token_uri<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        mutable_token_uri: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).mutable_token_uri = mutable_token_uri;
-    }
-
-    public entry fun set_tokens_burnable_by_creator<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        tokens_burnable_by_creator: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).tokens_burnable_by_creator = tokens_burnable_by_creator;
-    }
-
-    public entry fun set_tokens_freezable_by_creator<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        tokens_freezable_by_creator: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).tokens_freezable_by_creator = tokens_freezable_by_creator;
-    }
-
-    public entry fun set_soulbound<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-        soulbound: bool,
-    ) acquires CollectionProperties {
-        authorized_borrow_mut(creator, collection).soulbound = soulbound;
     }
 
     // ================================== View functions ================================== //
@@ -172,8 +96,8 @@ module minter::collection_properties {
     }
 
     #[view]
-    public fun tokens_freezable_by_creator<T: key>(collection: Object<T>): bool acquires CollectionProperties {
-        borrow(collection).tokens_freezable_by_creator
+    public fun tokens_transferable_by_creator<T: key>(collection: Object<T>): bool acquires CollectionProperties {
+        borrow(collection).tokens_transferable_by_creator
     }
 
     #[view]
@@ -188,25 +112,8 @@ module minter::collection_properties {
 
     // ================================== Private functions ================================== //
 
-    /// Only the creator of the collection can call this function, as they only own the properties
-    inline fun authorized_borrow_mut<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-    ): &mut CollectionProperties acquires CollectionProperties {
-        assert_collection_owner(signer::address_of(creator), collection);
-
-        borrow_global_mut<CollectionProperties>(collection_address(collection))
-    }
-
     inline fun borrow<T: key>(collection: Object<T>): &CollectionProperties {
         borrow_global<CollectionProperties>(collection_address(collection))
-    }
-
-    fun assert_collection_owner<T: key>(creator: address, collection: Object<T>) {
-        assert!(
-            object::owns(collection, creator),
-            error::permission_denied(ENOT_COLLECTION_OWNER),
-        );
     }
 
     fun collection_address<T: key>(token_minter: Object<T>): address {

--- a/token-minter/sources/token_minter.move
+++ b/token-minter/sources/token_minter.move
@@ -84,7 +84,7 @@ module minter::token_minter {
         mutable_token_properties: bool,
         mutable_token_uri: bool,
         tokens_burnable_by_creator: bool,
-        tokens_freezable_by_creator: bool,
+        tokens_transferable_by_creator: bool,
         royalty_numerator: u64,
         royalty_denominator: u64,
         creator_mint_only: bool,
@@ -93,7 +93,7 @@ module minter::token_minter {
         create_token_minter(
             creator, description, max_supply, name, uri, mutable_description, mutable_royalty, mutable_uri,
             mutable_token_description, mutable_token_name, mutable_token_properties, mutable_token_uri,
-            tokens_burnable_by_creator, tokens_freezable_by_creator, royalty_numerator, royalty_denominator,
+            tokens_burnable_by_creator, tokens_transferable_by_creator, royalty_numerator, royalty_denominator,
             creator_mint_only, soulbound,
         );
     }
@@ -115,7 +115,7 @@ module minter::token_minter {
         mutable_token_properties: bool,
         mutable_token_uri: bool,
         tokens_burnable_by_creator: bool,
-        tokens_freezable_by_creator: bool,
+        tokens_transferable_by_creator: bool,
         royalty_numerator: u64,
         royalty_denominator: u64,
         creator_mint_only: bool,
@@ -148,7 +148,7 @@ module minter::token_minter {
             mutable_token_properties,
             mutable_token_uri,
             tokens_burnable_by_creator,
-            tokens_freezable_by_creator,
+            tokens_transferable_by_creator,
             soulbound,
         );
 
@@ -305,10 +305,16 @@ module minter::token_minter {
             option::none()
         };
 
+        let transfer_ref = if (collection_properties::tokens_transferable_by_creator(collection)) {
+            option::some(object::generate_transfer_ref(token_constructor_ref))
+        } else {
+            option::none()
+        };
+
         move_to(&object::generate_signer(token_constructor_ref), TokenRefs {
             extend_ref: option::some(object::generate_extend_ref(token_constructor_ref)),
             burn_ref,
-            transfer_ref: option::none(),
+            transfer_ref,
             mutator_ref,
             property_mutator_ref: property_map::generate_mutator_ref(token_constructor_ref),
         });

--- a/token-minter/tests/utils/token_minter_utils.move
+++ b/token-minter/tests/utils/token_minter_utils.move
@@ -27,7 +27,7 @@ module minter::token_minter_utils {
         let mutable_token_properties = true;
         let mutable_token_uri = true;
         let tokens_burnable_by_creator = true;
-        let tokens_freezable_by_creator = true;
+        let tokens_transferable_by_creator = true;
 
         let token_minter = token_minter::create_token_minter(
             creator,
@@ -43,7 +43,7 @@ module minter::token_minter_utils {
             mutable_token_properties,
             mutable_token_uri,
             tokens_burnable_by_creator,
-            tokens_freezable_by_creator,
+            tokens_transferable_by_creator,
             ROYALTY_NUMERATOR,
             ROYALTY_DENOMINATOR,
             creator_mint_only,


### PR DESCRIPTION
Adding `transfer_ref` when `tokens_freezable_by_creator` is set to true, else none. 
- This ref is needed when creator has permissions to transfer tokens.
- Remove setters for `CollectionProperties`, as these should not be changed once initialized.
- Rename to `tokens_freezable_by_creator` to `tokens_transferable_by_creator`