### PR TITLE
Add transfer_object functions

### DIFF
--- a/example-composable/sources/main.move
+++ b/example-composable/sources/main.move
@@ -53,7 +53,7 @@ module example_composable::main {
             false,
             false,
             false,
-            false,
+            true, // tokens_transferrable_by_creator
             option::none(),
             true, // creator_mint_only
             false,
@@ -95,11 +95,10 @@ module example_composable::main {
         assert!(object::owner(powerup_token_obj) == sword_token_addr, 1);
 
         // Transfer powerup back to the user as the collection creator
-        token_minter::transfer_object_as_creator(
+        token_minter::transfer_as_creator(
             creator,
-            sword_token_obj,
             powerup_token_obj,
-            user_addr
+            user_addr,
         );
         assert!(object::owner(powerup_token_obj) == user_addr, 2);
 
@@ -108,12 +107,7 @@ module example_composable::main {
         assert!(object::owner(powerup_token_obj) == sword_token_addr, 3);
 
         // Transfer powerup back to the user as the token owner
-        token_minter::transfer_object_as_token_owner(
-            user,
-            sword_token_obj,
-            powerup_token_obj,
-            user_addr
-        );
+        object::transfer(user, powerup_token_obj, user_addr);
         assert!(object::owner(powerup_token_obj) == user_addr, 4);
     }
 }

--- a/token-minter/sources/token_minter.move
+++ b/token-minter/sources/token_minter.move
@@ -41,6 +41,8 @@ module minter::token_minter {
     const ENOT_OBJECT_CREATOR: u64 = 10;
     /// The caller does not own the token
     const ENOT_TOKEN_OWNER: u64 = 11;
+    /// The token does not support forced transfers
+    const ETOKEN_NOT_TRANSFERABLE: u64 = 12;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct TokenMinter has key {
@@ -462,45 +464,18 @@ module minter::token_minter {
         token::set_description(option::borrow(&token_refs.mutator_ref), description);
     }
 
-    public entry fun transfer_object_as_creator<T: key>(
+    /// Force transfer a token as the collection creator. Feature only works if
+    /// the `TransferRef` is stored in the `TokenRefs`.
+    public entry fun transfer_as_creator(
         creator: &signer,
         token: Object<Token>,
-        object: Object<T>,
         to_addr: address,
     ) acquires TokenRefs {
-        // TODO: Add checks for allowing this feature
-        // The Object storing `TokenMinterRefs` is the creator of the token
-        // collection. We need to check who is the owner of that Object
-        let token_creator = token::creator(token);
-        let token_minter_refs_object
-            = object::address_to_object<TokenMinterRefs>(token_creator);
-        assert!(
-            object::owner(token_minter_refs_object) == signer::address_of(creator),
-            ENOT_CREATOR,
-        );
-
-        let token_refs = borrow_global<TokenRefs>(token_address(&token));
-        transfer_object(token_refs, object, to_addr);
-    }
-
-    public entry fun transfer_object_as_token_owner<T: key>(
-        token_owner: &signer,
-        token: Object<Token>,
-        object: Object<T>,
-        to_addr: address,
-    ) acquires TokenRefs {
-        // TODO: Add checks for allowing this feature
-        let token_refs = authorized_borrow_token_refs(token, token_owner);
-        transfer_object(token_refs, object, to_addr);
-    }
-
-    fun transfer_object<T: key>(
-        token_refs: &TokenRefs,
-        object: Object<T>,
-        to_addr: address,
-    ) {
-        let token_refs_signer = &object::generate_signer_for_extending(&token_refs.extend_ref);
-        object::transfer(token_refs_signer, object, to_addr);
+        let token_refs = authorized_borrow_token_refs(token, creator);
+        assert!(option::is_some(&token_refs.transfer_ref), ETOKEN_NOT_TRANSFERABLE);
+        let transfer_ref = option::borrow(&token_refs.transfer_ref);
+        let linear_transfer_ref = object::generate_linear_transfer_ref(transfer_ref);
+        object::transfer_with_ref(linear_transfer_ref, to_addr)
     }
 
     // ================================= View Functions ================================= //


### PR DESCRIPTION
To fully support composability, we need to satisfy the following:

1. `Object`s can be transferred to our minted `Token`s
2. `Object`s can be transferred out from our minted `Token`s.

(1) is already supported by default
This PR implements support for (2) and adds example usage in the `example-composable` sources