### PR TITLE
Add Migration package to handle migrations from version x to version y

### DIFF
--- a/.github/workflows/move_tests.yml
+++ b/.github/workflows/move_tests.yml
@@ -58,3 +58,16 @@ jobs:
           nix_path: nixpkgs=channel:nixpkgs-unstable
       - name: Runs move tests.
         run: nix-shell --command 'aptos move test --dev'
+  migration:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./migration
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+      - name: Runs move tests.
+        run: nix-shell --command 'aptos move test --dev'

--- a/example-composable/Move.toml
+++ b/example-composable/Move.toml
@@ -10,6 +10,7 @@ example_composable = "_"
 example_composable = "0x12345"
 minter = "0x1c3e5574728c3d0d544f5679229fac153c5f7d78b323751b41860c5ffbb21cfd"
 minter_v2 = "0x456"
+migration = "0x789"
 
 [dependencies.TokenMinter]
 local = "../token-minter"

--- a/example-ownership/Move.toml
+++ b/example-ownership/Move.toml
@@ -10,6 +10,7 @@ example_ownership = "_"
 example_ownership = "0x123"
 minter = "0xb04204ddbcf130b6d1accfdd2e9593275cb6d4777d70ebd41a4799c007c55a2b"
 minter_v2 = "0x456"
+migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/ez-launch/Move.toml
+++ b/ez-launch/Move.toml
@@ -10,6 +10,7 @@ ez_launch = "_"
 ez_launch = "0x123"
 minter = "0x456"
 minter_v2 = "0x789"
+migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/launchpad/Move.toml
+++ b/launchpad/Move.toml
@@ -12,6 +12,7 @@ launchpad = "0x123"
 minter = "0xb04204ddbcf130b6d1accfdd2e9593275cb6d4777d70ebd41a4799c007c55a2b"
 launchpad_admin = "0x678"
 minter_v2 = "0x456"
+migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/migration/Move.toml
+++ b/migration/Move.toml
@@ -1,17 +1,19 @@
 [package]
-name = "TokenMinter"
+name = "Migration"
 version = "1.0.0"
 authors = []
+upgrade_policy = "compatible"
 
 [addresses]
-minter = "_"
-minter_v2 = "_"
 migration = "_"
 
 [dev-addresses]
 minter = "0x123"
 minter_v2 = "0x456"
 migration = "0x789"
+
+[dependencies.TokenMinter]
+local = "../token-minter"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/migration/shell.nix
+++ b/migration/shell.nix
@@ -1,0 +1,21 @@
+with import <nixpkgs> { };
+
+pkgs.mkShell {
+  buildInputs = [
+    jq
+    nodePackages.nodemon
+    nodejs_18
+    (callPackage ../aptos.nix { })
+  ];
+
+  shellHook = ''
+    alias gen="aptos init"
+
+    test() {
+      nodemon \
+        --ignore build/* \
+        --ext move \
+        --exec 'aptos move test --dev --skip-fetch-latest-git-deps;'
+    }
+  '';
+}

--- a/migration/sources/migration.move
+++ b/migration/sources/migration.move
@@ -1,0 +1,283 @@
+/// This module migrate the token refs from version x to version y contract.
+module migration::migration {
+
+    use std::signer;
+    use std::string::String;
+    use aptos_framework::object;
+    use aptos_framework::object::ExtendRef;
+
+    #[test_only]
+    use std::string;
+    #[test_only]
+    use aptos_framework::event;
+    #[test_only]
+    use aptos_framework::object::Object;
+    #[test_only]
+    use aptos_token_objects::collection::Collection;
+    #[test_only]
+    use aptos_token_objects::token::Token;
+    #[test_only]
+    use minter::collection_components;
+    #[test_only]
+    use minter::collection_properties;
+    #[test_only]
+    use minter::token_components;
+    #[test_only]
+    use minter_v2::collection_components_v2;
+    #[test_only]
+    use minter_v2::collection_properties_v2;
+    #[test_only]
+    use minter_v2::token_components_v2;
+
+    /// Migration function used for migrating the refs from one object to another.
+    /// This is called when the contract has been upgraded to a new address and version.
+    /// This function is used to migrate the refs from the old object to the new object.
+
+    /// Not the owner of the migration contract.
+    const ENOT_MIGRATION_CONTRACT_OWNER: u64 = 1;
+
+    const MIGRATION_CONTRACT_SEED: vector<u8> = b"migration::migration_contract";
+
+    struct MigrationRefs has key {
+        extend_ref: ExtendRef,
+    }
+
+    #[event]
+    /// Event emitted when code is published to an object.
+    struct Migrate has drop, store {
+        module_name: String,
+        old_address: address,
+        new_address: address,
+    }
+
+    fun init_module(creator: &signer) {
+        assert!(signer::address_of(creator) == @migration, ENOT_MIGRATION_CONTRACT_OWNER);
+
+        let constructor_ref = &object::create_named_object(creator, MIGRATION_CONTRACT_SEED);
+        let migration_signer = &object::generate_signer(constructor_ref);
+
+        move_to(migration_signer, MigrationRefs {
+            extend_ref: object::generate_extend_ref(constructor_ref),
+        });
+    }
+
+    #[view]
+    public fun migration_object_address(): address {
+        object::create_object_address(&@migration, MIGRATION_CONTRACT_SEED)
+    }
+
+
+    // =========================== Migration function examples for testing =========================== //
+
+    #[test_only]
+    /// Migrate `TokenRefs` from vx to vy contract - anyone can call this/migrate their contracts,
+    /// as long as the `collection_owner` is the owner of the token's collection.
+    public fun migrate_vx_to_vy_token_refs_and_properties(
+        collection_owner: &signer,
+        token: Object<Token>
+    ) acquires MigrationRefs {
+        // Get migration signer object
+        let migration_refs = borrow_global<MigrationRefs>(migration_object_address());
+        let migration_signer = &object::generate_signer_for_extending(&migration_refs.extend_ref);
+
+        let token_signer = &token_components::token_object_signer(collection_owner, token);
+
+        // Migrate out the token refs from vx contract
+        let extend_ref = token_components::migrate_out_extend_ref(migration_signer, collection_owner, token);
+        let burn_ref = token_components::migrate_out_burn_ref(migration_signer, collection_owner, token);
+        let transfer_ref = token_components::migrate_out_transfer_ref(migration_signer, collection_owner, token);
+        let mutator_ref = token_components::migrate_out_mutator_ref(migration_signer, collection_owner, token);
+        let property_mutator_ref = token_components::migrate_out_property_mutator_ref(
+            migration_signer,
+            collection_owner,
+            token
+        );
+
+        // Migrate in the token refs to vy contract
+        token_components_v2::migrate_in_extend_ref(migration_signer, collection_owner, token_signer, token, extend_ref);
+        token_components_v2::migrate_in_burn_ref(migration_signer, collection_owner, token_signer, token, burn_ref);
+        token_components_v2::migrate_in_transfer_ref(
+            migration_signer,
+            collection_owner,
+            token_signer,
+            token,
+            transfer_ref
+        );
+        token_components_v2::migrate_in_mutator_ref(
+            migration_signer,
+            collection_owner,
+            token_signer,
+            token,
+            mutator_ref
+        );
+        token_components_v2::migrate_in_property_mutator_ref(
+            migration_signer,
+            collection_owner,
+            token_signer,
+            token,
+            property_mutator_ref
+        );
+
+        event::emit(Migrate {
+            module_name: string::utf8(b"token_migration"),
+            old_address: @minter,
+            new_address: @minter_v2,
+        });
+    }
+
+    #[test_only]
+    /// Migrate `CollectionRefs` and `CollectionProperties` from v1 to v2 contract.
+    /// The creator must be the owner of the collection.
+    public fun migrate_vx_to_vy_collection_refs_and_properties(
+        collection_owner: &signer,
+        collection: Object<Collection>
+    ) acquires MigrationRefs {
+        // Get migration signer object
+        let migration_refs = borrow_global<MigrationRefs>(migration_object_address());
+        let migration_signer = &object::generate_signer_for_extending(&migration_refs.extend_ref);
+
+        let collection_signer = &collection_components::collection_object_signer(collection_owner, collection);
+
+        // Migrate collection properties from vx to vy contract
+        migrate_vx_to_vy_collection_properties(migration_signer, collection_owner, collection_signer, collection);
+
+        // Migrate out the collection refs from vx contract
+        let mutator_ref = collection_components::migrate_out_mutator_ref(
+            migration_signer,
+            collection_owner,
+            collection,
+        );
+        let royalty_mutator_ref = collection_components::migrate_out_royalty_mutator_ref(
+            migration_signer,
+            collection_owner,
+            collection,
+        );
+        let extend_ref = collection_components::migrate_out_extend_ref(migration_signer, collection_owner, collection);
+
+        // Migrate in the collection refs to vy contract
+        collection_components_v2::migrate_in_mutator_ref(
+            migration_signer,
+            collection_owner,
+            collection_signer,
+            collection,
+            mutator_ref,
+        );
+        collection_components_v2::migrate_in_royalty_mutator_ref(
+            migration_signer,
+            collection_owner,
+            collection_signer,
+            collection,
+            royalty_mutator_ref,
+        );
+        collection_components_v2::migrate_in_extend_ref(
+            migration_signer,
+            collection_owner,
+            collection_signer,
+            collection,
+            extend_ref
+        );
+
+        event::emit(Migrate {
+            module_name: string::utf8(b"collection_components"),
+            old_address: @minter,
+            new_address: @minter_v2,
+        });
+    }
+
+    #[test_only]
+    /// Migration function used for migrating the properties from one object to another.
+    fun migrate_vx_to_vy_collection_properties(
+        migration_signer: &signer,
+        collection_owner: &signer,
+        collection_signer: &signer,
+        collection: Object<Collection>,
+    ) {
+        // Migrate out the collection properties from v1 contract
+        let properties_v1 = &collection_properties::migrate_out_collection_properties(
+            migration_signer,
+            collection_owner,
+            collection
+        );
+        let (mutable_description_value, mutable_description_initialized) =
+            collection_properties::mutable_description(properties_v1);
+        let (mutable_uri_value, mutable_uri_initialized) =
+            collection_properties::mutable_uri(properties_v1);
+        let (mutable_token_description_value, mutable_token_description_initialized) =
+            collection_properties::mutable_token_description(properties_v1);
+        let (mutable_token_name_value, mutable_token_name_initialized) =
+            collection_properties::mutable_token_name(properties_v1);
+        let (mutable_token_properties_value, mutable_token_properties_initialized) =
+            collection_properties::mutable_token_properties(properties_v1);
+        let (mutable_token_uri_value, mutable_token_uri_initialized) =
+            collection_properties::mutable_token_uri(properties_v1);
+        let (mutable_royalty_value, mutable_royalty_initialized) =
+            collection_properties::mutable_royalty(properties_v1);
+        let (tokens_burnable_by_collection_owner_value, tokens_burnable_by_collection_owner_initialized) =
+            collection_properties::tokens_burnable_by_collection_owner(properties_v1);
+        let (tokens_transferable_by_collection_owner_value, tokens_transferable_by_collection_owner_initialized) =
+            collection_properties::tokens_transferable_by_collection_owner(properties_v1);
+
+        // Create CollectionProperties V2 values
+        let mutable_description = collection_properties_v2::create_property(
+            mutable_description_value,
+            mutable_description_initialized
+        );
+        let mutable_uri = collection_properties_v2::create_property(mutable_uri_value, mutable_uri_initialized);
+        let mutable_token_description = collection_properties_v2::create_property(
+            mutable_token_description_value,
+            mutable_token_description_initialized,
+        );
+        let mutable_token_name = collection_properties_v2::create_property(
+            mutable_token_name_value,
+            mutable_token_name_initialized
+        );
+        let mutable_token_properties = collection_properties_v2::create_property(
+            mutable_token_properties_value,
+            mutable_token_properties_initialized,
+        );
+        let mutable_token_uri = collection_properties_v2::create_property(
+            mutable_token_uri_value,
+            mutable_token_uri_initialized
+        );
+        let mutable_royalty = collection_properties_v2::create_property(
+            mutable_royalty_value,
+            mutable_royalty_initialized
+        );
+        let tokens_burnable_by_collection_owner = collection_properties_v2::create_property(
+            tokens_burnable_by_collection_owner_value,
+            tokens_burnable_by_collection_owner_initialized,
+        );
+        let tokens_transferable_by_collection_owner = collection_properties_v2::create_property(
+            tokens_transferable_by_collection_owner_value,
+            tokens_transferable_by_collection_owner_initialized,
+        );
+
+        // Migrate in the collection properties to v2 contract
+        collection_properties_v2::migrate_in_collection_properties(
+            migration_signer,
+            collection_owner,
+            collection_signer,
+            collection,
+            mutable_description,
+            mutable_uri,
+            mutable_token_description,
+            mutable_token_name,
+            mutable_token_properties,
+            mutable_token_uri,
+            mutable_royalty,
+            tokens_burnable_by_collection_owner,
+            tokens_transferable_by_collection_owner,
+        );
+
+        event::emit(Migrate {
+            module_name: string::utf8(b"collection_properties"),
+            old_address: @minter,
+            new_address: @minter_v2,
+        });
+    }
+
+    #[test_only]
+    public fun init_module_for_testing(creator: &signer) {
+        init_module(creator)
+    }
+}

--- a/migration/tests/collection_migration_tests.move
+++ b/migration/tests/collection_migration_tests.move
@@ -1,11 +1,12 @@
 #[test_only]
-module minter::collection_migration_tests {
+module migration::collection_migration_tests {
     use std::option;
     use std::signer;
     use std::string::utf8;
 
     use aptos_token_objects::collection;
     use aptos_token_objects::royalty;
+    use migration::migration;
 
     use minter::collection_components;
     use minter::collection_properties;
@@ -13,12 +14,24 @@ module minter::collection_migration_tests {
     use minter_v2::collection_components_v2;
     use minter_v2::collection_properties_v2;
 
-    #[test(creator = @0x123)]
-    /// Example of creating a v1 CollectionRefs and then migrating it to v2 CollectionRefs.
-    fun test_collection_mutator_ref_migration(creator: &signer) {
+    #[test_only]
+    fun setup(creator: &signer) {
+        migration::init_module_for_testing(creator);
+    }
+
+    #[test(creator = @0x123, migration = @migration)]
+    /// Example of creating a v1 CollectionRefs extend ref and then migrating it to v2 CollectionRefs extend ref.
+    fun test_collection_extend_ref_migration(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
 
-        // Use the v1 contract and CollectionRefs mutator ref to mutate collection description
+        // =============================== Test v1 refs =============================== //
+        // We check to see all v1 refs working as expected.
+
+        // extend_ref test - get collection_signer from v1 contract - this should not throw
+        let _collection_signer = &collection_components::collection_object_signer(creator, collection);
+
+        // mutator_ref test
         collection_components::set_collection_description(
             creator,
             collection,
@@ -26,75 +39,60 @@ module minter::collection_migration_tests {
         );
         assert!(collection::description(collection) == utf8(b"updated test collection description"), 0);
 
-        // =============================== MIGRATION OCCURS HERE =============================== //
+        // royalty_mutator_ref test
+        let royalty = royalty::create(0, 100, signer::address_of(creator));
+        collection_components::set_collection_royalties(creator, collection, royalty);
+        assert!(royalty::get(collection) == option::some(royalty), 0);
 
-        // We will call the v2 contract now, as we will simulate a migration from v1 to v2.
-        // First, we must migrate the mutator ref that belong to the collection.
-        // This will create the new CollectionRefs defined in v2 contract if it doesn't exist, else create the mutator ref.
-        collection_components_v2::migrate_v1_mutator_ref_to_v2(creator, collection);
+        // // =============================== MIGRATION OCCURS HERE =============================== //
+        // Call intermediary contract to migrate the collection refs from v1 to v2
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
 
-        // Now try mutating the collection again, but using the v2 CollectionRefs  mutator ref and v2 contract.
+        // =============================== Test v2 refs =============================== //
+
+        // extend_ref test - get collection_signer from v2 contract - this should not throw
+        let _collection_signer = collection_components_v2::collection_object_signer(creator, collection);
+
+        // royalty_mutator_ref test
+        let royalty_v2 = royalty::create(50, 100, signer::address_of(creator));
+        collection_components_v2::set_collection_royalties(creator, collection, royalty_v2);
+        assert!(royalty::get(collection) == option::some(royalty_v2), 0);
+
+        // mutator_ref test
         collection_components_v2::set_collection_description(creator, collection, utf8(b"v2 collection description"));
         assert!(collection::description(collection) == utf8(b"v2 collection description"), 0);
     }
 
-    #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 393217, location = minter_v2::collection_components_v2)]
+    #[test(creator = @0x123, migration = @migration)]
+    #[expected_failure(abort_code = 393217, location = minter_v2::collection_properties_v2)]
     /// Example of trying to mutate a collection using v2 contract and CollectionRefs, but without migrating the CollectionRefs mutator ref.
-    fun fails_to_mutate_when_mutator_ref_is_not_migrated(creator: &signer) {
+    fun fails_to_mutate_when_mutator_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
+        // let collection_signer = &collection_components::collection_object_signer(creator, collection);
 
         // We will call the v2 contract now, but should expect failure if user does not migrate the mutator ref.
         // We expect exception to be thrown here, as we are trying to use v2 contract without migrating the mutator ref.
         collection_components_v2::set_collection_description(creator, collection, utf8(b"v2 collection description"));
     }
 
-    #[test(creator = @0x123)]
-    /// Example of creating a v1 CollectionRefs extend ref and then migrating it to v2 CollectionRefs extend ref.
-    fun test_collection_extend_ref_migration(creator: &signer) {
-        let collection = collection_utils::create_collection_with_refs(creator);
-        // This should not throw when getting collection signer from v1 contract
-        let _collection_signer = collection_components::collection_object_signer(creator, collection);
-
-        // =============================== MIGRATION OCCURS HERE =============================== //
-        collection_components_v2::migrate_v1_extend_ref_to_v2(creator, collection);
-
-        // Now get collection_signer from v2 contract, this should not throw as we migrated the extend ref
-        let _collection_signer = collection_components_v2::collection_object_signer(creator, collection);
-    }
-
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     #[expected_failure(abort_code = 393217, location = minter_v2::collection_components_v2)]
     /// Example of trying to mutate a collection using v2 contract and CollectionRefs, but without migrating the CollectionRefs extend ref.
-    fun fails_to_mutate_when_extend_ref_is_not_migrated(creator: &signer) {
+    fun fails_to_get_signer_when_extend_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
-
         // Now get collection_signer from v2 contract, this throws as the extend ref was not migrated
         let _collection_signer = collection_components_v2::collection_object_signer(creator, collection);
     }
 
-    #[test(creator = @0x123)]
-    /// Example of creating a v1 CollectionRefs royalty_mutator ref and then migrating it to v2 CollectionRefs royalty_mutator ref.
-    fun test_collection_royalty_mutator_ref_migration(creator: &signer) {
-        let collection = collection_utils::create_collection_with_refs(creator);
-        let royalty = royalty::create(0, 100, signer::address_of(creator));
-        collection_components::set_collection_royalties(creator, collection, royalty);
-        assert!(royalty::get(collection) == option::some(royalty), 0);
-
-        // =============================== MIGRATION OCCURS HERE =============================== //
-        collection_components_v2::migrate_v1_royalty_mutator_ref_to_v2(creator, collection);
-
-        // Set royalty in v2 contract
-        let royalty_v2 = royalty::create(50, 100, signer::address_of(creator));
-        collection_components_v2::set_collection_royalties(creator, collection, royalty_v2);
-        assert!(royalty::get(collection) == option::some(royalty_v2), 0);
-    }
-
-    #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 393217, location = minter_v2::collection_components_v2)]
+    #[test(creator = @0x123, migration = @migration)]
+    #[expected_failure(abort_code = 393217, location = minter_v2::collection_properties_v2)]
     /// Example of trying to change collection's royalty, but without migrating the CollectionRefs royalty mutator ref.
-    fun fails_to_mutate_when_royalty_mutator_ref_is_not_migrated(creator: &signer) {
+    fun fails_to_mutate_when_royalty_mutator_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
+        // let collection_signer = &collection_components::collection_object_signer(creator, collection);
         let royalty = royalty::create(0, 100, signer::address_of(creator));
 
         // This throws
@@ -103,10 +101,11 @@ module minter::collection_migration_tests {
 
     // =============================== CollectionProperties Migration =============================== //
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     /// Example of creating a v1 CollectionProperties and then migrating it to v2 CollectionProperties.
     /// This test will create a collection with v1 CollectionProperties and then migrate it to v2 CollectionProperties.
-    fun test_collection_properties_migration(creator: &signer) {
+    fun test_collection_properties_migration(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
 
         // Use the v1 contract and CollectionProperties to set collection properties
@@ -118,17 +117,21 @@ module minter::collection_migration_tests {
         // We will call the v2 contract now, as we will simulate a migration from v1 to v2.
         // First, we must migrate the properties that belong to the collection.
         // This will create the new CollectionProperties defined in v2 contract.
-        collection_properties_v2::migrate_v1_collection_properties_to_v2(creator, collection);
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
 
         // Now try setting the collection properties again, but using the v2 CollectionProperties and v2 contract.
         collection_properties_v2::set_mutable_token_name(creator, collection, false);
         assert!(collection_properties_v2::is_mutable_token_name(collection) == false, 0);
+
+        collection_properties_v2::set_tokens_burnable_by_collection_owner(creator, collection, false);
+        assert!(collection_properties_v2::is_tokens_burnable_by_collection_owner(collection) == false, 0);
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     #[expected_failure(abort_code = 393217, location = minter_v2::collection_properties_v2)]
     /// Example of trying to mutate a collection using v2 contract and CollectionProperties, but without migrating the CollectionProperties.
-    fun fails_to_mutate_when_collection_properties_are_not_migrated(creator: &signer) {
+    fun fails_to_mutate_when_collection_properties_are_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
 
         // We will call the v2 contract now, but should expect failure if user does not migrate the properties.

--- a/migration/tests/token_migration_tests.move
+++ b/migration/tests/token_migration_tests.move
@@ -1,20 +1,27 @@
 #[test_only]
-module minter::token_migration_tests {
+module migration::token_migration_tests {
     use std::bcs;
     use std::signer;
     use std::string;
     use std::string::utf8;
 
     use aptos_token_objects::token;
-
     use minter::collection_utils;
     use minter::token_components;
     use minter::token_utils;
     use minter_v2::token_components_v2;
 
-    #[test(creator = @0x123)]
+    use migration::migration;
+
+    #[test_only]
+    fun setup(migration: &signer) {
+        migration::init_module_for_testing(migration);
+    }
+
+    #[test(creator = @0x123, migration = @migration)]
     /// Example of creating a v1 TokenRefs extend ref and then migrating it to v2 TokenRefs extend ref.
-    fun test_token_extend_ref_migration(creator: &signer) {
+    fun test_token_extend_ref_migration(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
 
@@ -22,16 +29,17 @@ module minter::token_migration_tests {
         let _token_signer = token_components::token_object_signer(creator, token);
 
         // =============================== MIGRATION OCCURS HERE =============================== //
-        token_components_v2::migrate_v1_extend_ref_to_v2(creator, token);
+        migration::migrate_vx_to_vy_token_refs_and_properties(creator, token);
 
         // Now get collection_signer from v2 contract, this should not throw as we migrated the extend ref
         let _token_signer = token_components_v2::token_object_signer(creator, token);
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     #[expected_failure(abort_code = 393217, location = minter_v2::token_components_v2)]
     /// Example of trying to mutate a token using v2 contract and TokenRefs, but without migrating the TokenRefs extend ref.
-    fun fails_to_mutate_when_extend_ref_is_not_migrated(creator: &signer) {
+    fun fails_to_get_signer_when_extend_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
 
@@ -39,24 +47,29 @@ module minter::token_migration_tests {
         let _token_signer = token_components_v2::token_object_signer(creator, token);
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     /// Example of creating a v1 TokenRefs burn_ref and then migrating it to v2 TokenRefs burn_ref.
-    fun test_burn_ref_migration(creator: &signer) {
+    fun test_burn_ref_migration(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
         token_components::burn(creator, token);
 
         // Create new token as we burnt the previous one
         let new_token = token_utils::create_token_with_refs(creator, collection);
-        token_components_v2::migrate_v1_burn_ref_to_v2(creator, new_token);
+
+        // Must migrate collection properties as well, as we are burning the token.
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
+        migration::migrate_vx_to_vy_token_refs_and_properties(creator, new_token);
 
         // Now try burning a new token, but using the v2 TokenRefs burn ref and v2 contract.
         token_components_v2::burn(creator, new_token);
     }
 
-    #[test(creator = @0x123)]
-    #[expected_failure(abort_code = 393217, location = minter_v2::token_components_v2)]
-    fun fails_to_burn_when_burn_ref_is_not_migrated(creator: &signer) {
+    #[test(creator = @0x123, migration = @migration)]
+    #[expected_failure(abort_code = 393217, location = minter_v2::collection_properties_v2)]
+    fun fails_to_burn_when_burn_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
 
@@ -64,9 +77,10 @@ module minter::token_migration_tests {
         token_components_v2::burn(creator, token);
     }
 
-    #[test(creator = @0x123, user = @0x456)]
+    #[test(creator = @0x123, user = @0x456, migration = @migration)]
     /// Example of creating a v1 TokenRefs transfer_ref and then migrating it to v2 TokenRefs transfer_ref.
-    fun test_transfer_ref_migration(creator: &signer, user: &signer) {
+    fun test_transfer_ref_migration(creator: &signer, user: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
         let user_address = signer::address_of(user);
@@ -74,25 +88,33 @@ module minter::token_migration_tests {
 
         // Create new token as we transferred the previous one
         let new_token = token_utils::create_token_with_refs(creator, collection);
-        token_components_v2::migrate_v1_transfer_ref_to_v2(creator, new_token);
+
+        // Must migrate collection properties as well, as we are transferring to a new token.
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
+        migration::migrate_vx_to_vy_token_refs_and_properties(creator, new_token);
 
         // Now try transferring a new token, but using the v2 TokenRefs burn ref and v2 contract.
         token_components_v2::transfer_as_collection_owner(creator, new_token, user_address);
     }
 
-    #[test(creator = @0x123, user = @0x456)]
+    #[test(creator = @0x123, user = @0x456, migration = @migration)]
     #[expected_failure(abort_code = 393217, location = minter_v2::token_components_v2)]
-    fun fails_to_transfer_when_transfer_ref_is_not_migrated(creator: &signer, user: &signer) {
+    fun fails_to_transfer_when_transfer_ref_is_not_migrated(creator: &signer, user: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
+
+        // Must migrate collection properties as well, as we are transferring to a new token.
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
 
         // We will call the v2 contract now, but should expect failure if user does not migrate refs.
         token_components_v2::transfer_as_collection_owner(creator, token, signer::address_of(user));
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     /// Example of creating a v1 TokenRefs mutator_ref and then migrating it to v2 TokenRefs mutator_ref.
-    fun test_mutator_ref_migration(creator: &signer) {
+    fun test_mutator_ref_migration(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
 
@@ -102,31 +124,37 @@ module minter::token_migration_tests {
 
         // =============================== MIGRATION OCCURS HERE =============================== //
 
+        // Must migrate collection properties as well, as we are setting the description for token.
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
+
         // We will call the v2 contract now, as we will simulate a migration from v1 to v2.
         // First, we must migrate the TokenRefs mutator ref that belong to the token.
         // This will create the new TokenRefs mutator ref defined in v2 contract.
-        token_components_v2::migrate_v1_mutator_ref_to_v2(creator, token);
+        migration::migrate_vx_to_vy_token_refs_and_properties(creator, token);
 
         // Now try mutating the token again, but using the v2 TokenRefs mutator_ref and v2 contract.
         token_components_v2::set_description(creator, token, utf8(b"v2 token description"));
         assert!(token::description(token) == utf8(b"v2 token description"), 0);
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     #[expected_failure(abort_code = 393217, location = minter_v2::token_components_v2)]
     /// Example of trying to mutate a token using v2 contract and TokenRefs, but without migrating the TokenRefs mutator ref.
-    fun fails_to_mutate_when_mutator_ref_is_not_migrated(creator: &signer) {
+    fun fails_to_mutate_when_mutator_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
 
         // We will call the v2 contract now, but should expect failure if user does not migrate refs.
         // We expect exception to be thrown here, as we are trying to use v2 contract without migrating refs.
         token_components_v2::set_description(creator, token, utf8(b"v2 token description"));
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     /// Example of creating a v1 TokenRefs property_mutator_ref and then migrating it to v2 TokenRefs property_mutator_ref.
-    fun test_property_mutator_ref_migration(creator: &signer) {
+    fun test_property_mutator_ref_migration(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
         token_components::add_property(
@@ -137,7 +165,8 @@ module minter::token_migration_tests {
             bcs::to_bytes<u8>(&0x12),
         );
 
-        token_components_v2::migrate_v1_property_mutator_ref_to_v2(creator, token);
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
+        migration::migrate_vx_to_vy_token_refs_and_properties(creator, token);
 
         // Now try updating properties for the token.
         token_components_v2::update_property(
@@ -149,9 +178,10 @@ module minter::token_migration_tests {
         );
     }
 
-    #[test(creator = @0x123)]
+    #[test(creator = @0x123, migration = @migration)]
     #[expected_failure(abort_code = 393217, location = minter_v2::token_components_v2)]
-    fun fails_to_transfer_when_property_mutator_ref_is_not_migrated(creator: &signer) {
+    fun fails_to_transfer_when_property_mutator_ref_is_not_migrated(creator: &signer, migration: &signer) {
+        setup(migration);
         let collection = collection_utils::create_collection_with_refs(creator);
         let token = token_utils::create_token_with_refs(creator, collection);
         token_components::add_property(
@@ -161,6 +191,7 @@ module minter::token_migration_tests {
             string::utf8(b"u8"),
             bcs::to_bytes<u8>(&0x12),
         );
+        migration::migrate_vx_to_vy_collection_refs_and_properties(creator, collection);
 
         // Now try updating properties for the token, this will fail as we did not migrate the property mutator ref.
         token_components_v2::update_property(

--- a/token-minter/sources/migration/migration_helper.move
+++ b/token-minter/sources/migration/migration_helper.move
@@ -1,0 +1,13 @@
+module minter::migration_helper {
+
+    use aptos_framework::object;
+
+    // The seed for the migration contract
+    const MIGRATION_CONTRACT_SEED: vector<u8> = b"migration::migration_contract";
+
+    #[view]
+    /// Helper function to get the address of the migration object signer.
+    public fun migration_object_address(): address {
+        object::create_object_address(&@migration, MIGRATION_CONTRACT_SEED)
+    }
+}

--- a/token-minter/sources/modules/collection_components.move
+++ b/token-minter/sources/modules/collection_components.move
@@ -10,6 +10,7 @@ module minter::collection_components {
     use aptos_token_objects::collection;
     use aptos_token_objects::collection::Collection;
     use aptos_token_objects::royalty;
+    use minter::migration_helper;
 
     use minter::collection_properties;
     use minter::collection_properties::CollectionProperties;
@@ -22,6 +23,8 @@ module minter::collection_components {
     const EFIELD_NOT_MUTABLE: u64 = 3;
     /// The collection does not have ExtendRef, so it is not extendable.
     const ECOLLECTION_NOT_EXTENDABLE: u64 = 4;
+    /// Not the migration object signer.
+    const ENOT_MIGRATION_SIGNER: u64 = 5;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct CollectionRefs has key {
@@ -40,13 +43,12 @@ module minter::collection_components {
     public fun create_refs_and_properties(constructor_ref: &ConstructorRef): Object<CollectionRefs> {
         let collection_signer = &object::generate_signer(constructor_ref);
 
-        move_to(collection_signer, CollectionRefs {
-            mutator_ref: option::some(collection::generate_mutator_ref(constructor_ref)),
-            royalty_mutator_ref: option::some(
-                royalty::generate_mutator_ref(object::generate_extend_ref(constructor_ref))
-            ),
-            extend_ref: option::some(object::generate_extend_ref(constructor_ref)),
-        });
+        init_collection_refs(
+            collection_signer,
+            option::some(collection::generate_mutator_ref(constructor_ref)),
+            option::some(royalty::generate_mutator_ref(object::generate_extend_ref(constructor_ref))),
+            option::some(object::generate_extend_ref(constructor_ref)),
+        );
 
         let properties = create_default_properties(true);
         collection_properties::init(constructor_ref, properties);
@@ -55,7 +57,7 @@ module minter::collection_components {
     }
 
     fun create_default_properties(value: bool): CollectionProperties {
-        collection_properties::create_properties(value, value, value, value, value, value, value, value, value)
+        collection_properties::create_uninitialized_properties(value, value, value, value, value, value, value, value, value)
     }
 
     public fun set_collection_description(
@@ -65,7 +67,7 @@ module minter::collection_components {
     ) acquires CollectionRefs {
         assert!(is_mutable_description(collection), error::permission_denied(EFIELD_NOT_MUTABLE));
         collection::set_description(
-            option::borrow(&authorized_borrow_refs(collection, collection_owner).mutator_ref),
+            option::borrow(&authorized_borrow_refs_mut(collection, collection_owner).mutator_ref),
             description,
         );
     }
@@ -76,7 +78,7 @@ module minter::collection_components {
         uri: String,
     ) acquires CollectionRefs {
         assert!(is_mutable_uri(collection), error::permission_denied(EFIELD_NOT_MUTABLE));
-        collection::set_uri(option::borrow(&authorized_borrow_refs(collection, collection_owner).mutator_ref), uri);
+        collection::set_uri(option::borrow(&authorized_borrow_refs_mut(collection, collection_owner).mutator_ref), uri);
     }
 
     public fun set_collection_royalties(
@@ -86,16 +88,17 @@ module minter::collection_components {
     ) acquires CollectionRefs {
         assert!(is_mutable_royalty(collection), error::permission_denied(EFIELD_NOT_MUTABLE));
         royalty::update(
-            option::borrow(&authorized_borrow_refs(collection, collection_owner).royalty_mutator_ref),
+            option::borrow(&authorized_borrow_refs_mut(collection, collection_owner).royalty_mutator_ref),
             royalty
         );
     }
 
-    inline fun authorized_borrow_refs<T: key>(collection: Object<T>, collection_owner: &signer): &CollectionRefs {
+    inline fun authorized_borrow_refs_mut<T: key>(
+        collection: Object<T>,
+        collection_owner: &signer
+    ): &mut CollectionRefs {
         assert_owner(signer::address_of(collection_owner), collection);
-
-        let collection_address = collection_refs_address(collection);
-        borrow_global<CollectionRefs>(collection_address)
+        borrow_global_mut<CollectionRefs>(collection_refs_address(collection))
     }
 
     fun assert_owner<T: key>(collection_owner: address, obj: Object<T>) {
@@ -105,13 +108,26 @@ module minter::collection_components {
         );
     }
 
+    fun init_collection_refs(
+        collection_object_signer: &signer,
+        mutator_ref: Option<collection::MutatorRef>,
+        royalty_mutator_ref: Option<royalty::MutatorRef>,
+        extend_ref: Option<object::ExtendRef>,
+    ) {
+        move_to(collection_object_signer, CollectionRefs {
+            mutator_ref,
+            royalty_mutator_ref,
+            extend_ref,
+        });
+    }
+
     #[view]
     /// Can only be called if the `collection_owner` is the owner of the collection.
     public fun collection_object_signer<T: key>(
         collection_owner: &signer,
         collection: Object<T>,
     ): signer acquires CollectionRefs {
-        let extend_ref = &authorized_borrow_refs(collection, collection_owner).extend_ref;
+        let extend_ref = &authorized_borrow_refs_mut(collection, collection_owner).extend_ref;
         assert!(option::is_some(extend_ref), ECOLLECTION_NOT_EXTENDABLE);
 
         object::generate_signer_for_extending(option::borrow(extend_ref))
@@ -141,43 +157,49 @@ module minter::collection_components {
     /// Migration function used for migrating the refs from one object to another.
     /// This is called when the contract has been upgraded to a new address and version.
     /// This function is used to migrate the refs from the old object to the new object.
+    ///
+    /// Only the migration contract is allowed to call migration functions. The user must
+    /// call the migration function on the migration contract to migrate.
+    ///
+    /// To migrate in to the new contract, the `ExtendRef` must be present as the `ExtendRef`
+    /// is used to generate the collection object signer.
 
-    public fun migrate_extend_ref(
+    public fun migrate_out_extend_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         collection: Object<Collection>,
     ): Option<object::ExtendRef> acquires CollectionRefs {
-        assert_owner(signer::address_of(collection_owner), collection);
-        let collection_address = collection_refs_address(collection);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<CollectionRefs>(collection_address);
+        let refs = authorized_borrow_refs_mut(collection, collection_owner);
         let extend_ref = extract_ref_if_present(&mut refs.extend_ref);
-        destroy_collection_refs_if_all_refs_migrated(refs, collection_address);
+        destroy_collection_refs_if_all_refs_migrated(refs, object::object_address(&collection));
         extend_ref
     }
 
-    public fun migrate_mutator_ref(
+    public fun migrate_out_mutator_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         collection: Object<Collection>,
     ): Option<collection::MutatorRef> acquires CollectionRefs {
-        assert_owner(signer::address_of(collection_owner), collection);
-        let collection_address = collection_refs_address(collection);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<CollectionRefs>(collection_address);
+        let refs = authorized_borrow_refs_mut(collection, collection_owner);
         let mutator_ref = extract_ref_if_present(&mut refs.mutator_ref);
-        destroy_collection_refs_if_all_refs_migrated(refs, collection_address);
+        destroy_collection_refs_if_all_refs_migrated(refs, object::object_address(&collection));
         mutator_ref
     }
 
-    public fun migrate_royalty_mutator_ref(
+    public fun migrate_out_royalty_mutator_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         collection: Object<Collection>,
     ): Option<royalty::MutatorRef> acquires CollectionRefs {
-        assert_owner(signer::address_of(collection_owner), collection);
-        let collection_address = collection_refs_address(collection);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<CollectionRefs>(collection_address);
+        let refs = authorized_borrow_refs_mut(collection, collection_owner);
         let royalty_mutator_ref = extract_ref_if_present(&mut refs.royalty_mutator_ref);
-        destroy_collection_refs_if_all_refs_migrated(refs, collection_address);
+        destroy_collection_refs_if_all_refs_migrated(refs, object::object_address(&collection));
         royalty_mutator_ref
     }
 
@@ -211,5 +233,10 @@ module minter::collection_components {
             error::not_found(ECOLLECTION_REFS_DOES_NOT_EXIST)
         );
         collection_address
+    }
+
+    fun assert_migration_object_signer(migration_signer: &signer) {
+        let migration_object_signer = migration_helper::migration_object_address();
+        assert!(signer::address_of(migration_signer) == migration_object_signer, ENOT_MIGRATION_SIGNER);
     }
 }

--- a/token-minter/sources/modules/token_components.move
+++ b/token-minter/sources/modules/token_components.move
@@ -11,6 +11,7 @@ module minter::token_components {
     use aptos_token_objects::property_map;
     use aptos_token_objects::token;
     use aptos_token_objects::token::Token;
+    use minter::migration_helper;
 
     use minter::collection_properties;
 
@@ -28,8 +29,10 @@ module minter::token_components {
     const ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER: u64 = 6;
     /// The token does not have ExtendRef, so it is not extendable.
     const ETOKEN_NOT_EXTENDABLE: u64 = 7;
+    /// Not the migration object signer.
+    const ENOT_MIGRATION_SIGNER: u64 = 8;
     /// This token is not owned by the address.
-    const ENOT_TOKEN_OWNER: u64 = 8;
+    const ENOT_TOKEN_OWNER: u64 = 9;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct TokenRefs has key {
@@ -74,7 +77,7 @@ module minter::token_components {
             is_transferable_by_collection_owner(token),
             error::permission_denied(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER),
         );
-        let transfer_ref = &authorized_borrow_refs(collection_owner, token).transfer_ref;
+        let transfer_ref = &authorized_borrow_refs_mut(collection_owner, token).transfer_ref;
         assert!(option::is_some(transfer_ref), error::not_found(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER));
 
         let linear_transfer_ref = object::generate_linear_transfer_ref(option::borrow(transfer_ref));
@@ -85,7 +88,7 @@ module minter::token_components {
         assert!(is_transferable_by_collection_owner(token), error::permission_denied(
             ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER
         ));
-        let transfer_ref = &authorized_borrow_refs(collection_owner, token).transfer_ref;
+        let transfer_ref = &authorized_borrow_refs_mut(collection_owner, token).transfer_ref;
         assert!(option::is_some(transfer_ref), error::not_found(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER));
 
         object::disable_ungated_transfer(option::borrow(transfer_ref));
@@ -96,7 +99,7 @@ module minter::token_components {
             is_transferable_by_collection_owner(token), error::permission_denied(
                 ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER
             ));
-        let transfer_ref = &authorized_borrow_refs(collection_owner, token).transfer_ref;
+        let transfer_ref = &authorized_borrow_refs_mut(collection_owner, token).transfer_ref;
         assert!(option::is_some(transfer_ref), error::not_found(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER));
 
         object::enable_ungated_transfer(option::borrow(transfer_ref));
@@ -108,7 +111,7 @@ module minter::token_components {
         description: String,
     ) acquires TokenRefs {
         assert!(is_mutable_description(token), error::permission_denied(EFIELD_NOT_MUTABLE));
-        let mutator_ref = &authorized_borrow_refs(collection_owner, token).mutator_ref;
+        let mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).mutator_ref;
         assert!(option::is_some(mutator_ref), error::not_found(EFIELD_NOT_MUTABLE));
 
         token::set_description(option::borrow(mutator_ref), description);
@@ -116,7 +119,7 @@ module minter::token_components {
 
     public fun set_name(collection_owner: &signer, token: Object<Token>, name: String) acquires TokenRefs {
         assert!(is_mutable_name(token), error::permission_denied(EFIELD_NOT_MUTABLE));
-        let mutator_ref = &authorized_borrow_refs(collection_owner, token).mutator_ref;
+        let mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).mutator_ref;
         assert!(option::is_some(mutator_ref), error::not_found(EFIELD_NOT_MUTABLE));
 
         token::set_name(option::borrow(mutator_ref), name);
@@ -124,7 +127,7 @@ module minter::token_components {
 
     public fun set_uri(collection_owner: &signer, token: Object<Token>, uri: String) acquires TokenRefs {
         assert!(is_mutable_uri(token), error::permission_denied(EFIELD_NOT_MUTABLE));
-        let mutator_ref = &authorized_borrow_refs(collection_owner, token).mutator_ref;
+        let mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).mutator_ref;
         assert!(option::is_some(mutator_ref), error::not_found(EFIELD_NOT_MUTABLE));
 
         token::set_uri(option::borrow(mutator_ref), uri);
@@ -138,7 +141,7 @@ module minter::token_components {
         value: vector<u8>,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::add(option::borrow(property_mutator_ref), key, type, value);
@@ -151,7 +154,7 @@ module minter::token_components {
         value: V,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::add_typed(option::borrow(property_mutator_ref), key, value);
@@ -159,7 +162,7 @@ module minter::token_components {
 
     public fun remove_property(collection_owner: &signer, token: Object<Token>, key: String) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::remove(option::borrow(property_mutator_ref), &key);
@@ -173,7 +176,7 @@ module minter::token_components {
         value: vector<u8>,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::update(option::borrow(property_mutator_ref), &key, type, value);
@@ -186,26 +189,25 @@ module minter::token_components {
         value: V,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::update_typed(option::borrow(property_mutator_ref), &key, value);
     }
 
     /// Allow borrowing the `TokenRefs` resource if the `collection_owner` owns the token's collection.
-    inline fun authorized_borrow_refs(collection_owner: &signer, token: Object<Token>): &TokenRefs {
+    inline fun authorized_borrow_refs_mut(collection_owner: &signer, token: Object<Token>): &mut TokenRefs {
         assert_token_collection_owner(signer::address_of(collection_owner), token);
-
         let token_address = object::object_address(&token);
         assert!(token_refs_exist(token_address), error::not_found(ETOKEN_REFS_DOES_NOT_EXIST));
 
-        borrow_global<TokenRefs>(token_address)
+        borrow_global_mut<TokenRefs>(token_address)
     }
 
     fun assert_token_collection_owner(collection_owner: address, token: Object<Token>) {
         let collection = token::collection_object(token);
         assert!(
-            object::owner(collection) == collection_owner || object::owns(collection, collection_owner),
+            object::owner(collection) == collection_owner,
             error::permission_denied(ENOT_TOKEN_COLLECTION_OWNER),
         );
     }
@@ -232,17 +234,10 @@ module minter::token_components {
         };
     }
 
-    fun assert_token_ownership<T: key>(owner: address, token: Object<T>) {
-        assert!(
-            object::owns(token::collection_object(token), owner),
-            error::permission_denied(ENOT_TOKEN_OWNER),
-        );
-    }
-
     #[view]
     /// Can only be called if the `collection_owner` is the owner of the collection the `token` belongs to.
     public fun token_object_signer(collection_owner: &signer, token: Object<Token>): signer acquires TokenRefs {
-        let extend_ref = &authorized_borrow_refs(collection_owner, token).extend_ref;
+        let extend_ref = &authorized_borrow_refs_mut(collection_owner, token).extend_ref;
         assert!(option::is_some(extend_ref), ETOKEN_NOT_EXTENDABLE);
 
         object::generate_signer_for_extending(option::borrow(extend_ref))
@@ -287,69 +282,75 @@ module minter::token_components {
     /// Migration function used for migrating the refs from one object to another.
     /// This is called when the contract has been upgraded to a new address and version.
     /// This function is used to migrate the refs from the old object to the new object.
+    ///
+    /// Only the migration contract is allowed to call migration functions. The user must
+    /// call the migration function on the migration contract to migrate.
+    ///
+    /// To migrate in to the new contract, the `ExtendRef` must be present as the `ExtendRef`
+    /// is used to generate the token object signer.
 
-    public fun migrate_extend_ref(
+    public fun migrate_out_extend_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<object::ExtendRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let extend_ref = extract_ref_if_present(&mut refs.extend_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         extend_ref
     }
 
-    public fun migrate_burn_ref(
+    public fun migrate_out_burn_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<token::BurnRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let burn_ref = extract_ref_if_present(&mut refs.burn_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         burn_ref
     }
 
-    public fun migrate_transfer_ref(
+    public fun migrate_out_transfer_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<object::TransferRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let transfer_ref = extract_ref_if_present(&mut refs.transfer_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         transfer_ref
     }
 
-    public fun migrate_mutator_ref(
+    public fun migrate_out_mutator_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<token::MutatorRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let mutator_ref = extract_ref_if_present(&mut refs.mutator_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         mutator_ref
     }
 
-    public fun migrate_property_mutator_ref(
+    public fun migrate_out_property_mutator_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<property_map::MutatorRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let property_mutator_ref = extract_ref_if_present(&mut refs.property_mutator_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         property_mutator_ref
     }
 
@@ -361,7 +362,10 @@ module minter::token_components {
         }
     }
 
-    inline fun destroy_token_refs_if_all_refs_migrated(token_refs: &mut TokenRefs, token_address: address) acquires TokenRefs {
+    inline fun destroy_token_refs_if_all_refs_migrated(
+        token_refs: &mut TokenRefs,
+        token_address: address
+    ) acquires TokenRefs {
         if (option::is_none(&token_refs.extend_ref)
             && option::is_none(&token_refs.burn_ref)
             && option::is_none(&token_refs.transfer_ref)
@@ -384,5 +388,10 @@ module minter::token_components {
             error::not_found(ETOKEN_REFS_DOES_NOT_EXIST)
         );
         token_address
+    }
+
+    fun assert_migration_object_signer(migration_signer: &signer) {
+        let migration_object_signer = migration_helper::migration_object_address();
+        assert!(signer::address_of(migration_signer) == migration_object_signer, ENOT_MIGRATION_SIGNER);
     }
 }

--- a/token-minter/tests/migration-contracts/collection_properties_v2.move
+++ b/token-minter/tests/migration-contracts/collection_properties_v2.move
@@ -7,8 +7,8 @@ module minter_v2::collection_properties_v2 {
     use aptos_framework::event;
     use aptos_framework::object::{Self, ConstructorRef, Object};
 
-    use minter::collection_components;
-    use minter::collection_properties;
+    use aptos_token_objects::collection::Collection;
+    use minter::migration_helper;
 
     /// Collection properties does not exist on this object.
     const ECOLLECTION_PROPERTIES_DOES_NOT_EXIST: u64 = 1;
@@ -18,6 +18,8 @@ module minter_v2::collection_properties_v2 {
     const ECOLLECTION_PROPERTY_ALREADY_INITIALIZED: u64 = 3;
     /// Collection properties already exists on this object.
     const ECOLLECTION_PROPERTIES_ALREADY_EXISTS: u64 = 4;
+    /// Not the migration object signer.
+    const ENOT_MIGRATION_SIGNER: u64 = 5;
 
     struct CollectionProperty has copy, drop, store {
         value: bool,
@@ -69,7 +71,7 @@ module minter_v2::collection_properties_v2 {
 
     /// Creates a new CollectionProperties resource with the values provided.
     /// These are initialized as `false`, and can only be changed once with the setter functions.
-    public fun create_properties(
+    public fun create_uninitialized_properties(
         mutable_description: bool,
         mutable_uri: bool,
         mutable_token_description: bool,
@@ -93,7 +95,7 @@ module minter_v2::collection_properties_v2 {
         }
     }
 
-    fun create_property(value: bool, initialized: bool): CollectionProperty {
+    public fun create_property(value: bool, initialized: bool): CollectionProperty {
         CollectionProperty { value, initialized }
     }
 
@@ -223,10 +225,17 @@ module minter_v2::collection_properties_v2 {
         collection_owner: &signer,
         obj: Object<T>,
     ): &mut CollectionProperties acquires CollectionProperties {
-        assert!(object::owner(obj) == signer::address_of(collection_owner), error::unauthenticated(ENOT_OBJECT_OWNER));
+        assert_owner(signer::address_of(collection_owner), obj);
         assert!(collection_properties_exists(obj), error::not_found(ECOLLECTION_PROPERTIES_DOES_NOT_EXIST));
 
         borrow_global_mut<CollectionProperties>(object::object_address(&obj))
+    }
+
+    fun assert_owner<T: key>(collection_owner: address, obj: Object<T>) {
+        assert!(
+            object::owner(obj) == collection_owner,
+            error::permission_denied(ENOT_OBJECT_OWNER),
+        );
     }
 
     public fun mutable_description(properties: &CollectionProperties): (bool, bool) {
@@ -286,8 +295,8 @@ module minter_v2::collection_properties_v2 {
     }
 
     #[view]
-    public fun is_mutable_token_name<T: key>(properties: Object<T>): bool acquires CollectionProperties {
-        borrow(properties).mutable_token_name.value
+    public fun is_mutable_token_name<T: key>(obj: Object<T>): bool acquires CollectionProperties {
+        borrow(obj).mutable_token_name.value
     }
 
     #[view]
@@ -320,66 +329,59 @@ module minter_v2::collection_properties_v2 {
     /// Migration function used for migrating the refs from one object to another.
     /// This is called when the contract has been upgraded to a new address and version.
     /// This function is used to migrate the refs from the old object to the new object.
-    public fun migrate_v1_collection_properties_to_v2<T: key>(
-        creator: &signer,
-        collection: Object<T>,
-    ) {
-        let collection_signer = &collection_components::collection_object_signer(creator, collection);
-        let properties = &collection_properties::migrate_collection_properties(creator, collection);
+    ///
+    /// To migrate in to the new contract, the `ExtendRef` must be present as the `ExtendRef`
+    /// is used to generate the collection object signer.
 
-        assert!(!collection_properties_exists(collection), error::invalid_state(ECOLLECTION_PROPERTIES_ALREADY_EXISTS));
-        let (mutable_description_value, mutable_description_initialized) =
-            collection_properties::mutable_description(properties);
-        let (mutable_uri_value, mutable_uri_initialized) =
-            collection_properties::mutable_uri(properties);
-        let (mutable_token_description_value, mutable_token_description_initialized) =
-            collection_properties::mutable_token_description(properties);
-        let (mutable_token_name_value, mutable_token_name_initialized) =
-            collection_properties::mutable_token_name(properties);
-        let (mutable_token_properties_value, mutable_token_properties_initialized) =
-            collection_properties::mutable_token_properties(properties);
-        let (mutable_token_uri_value, mutable_token_uri_initialized) =
-            collection_properties::mutable_token_uri(properties);
-        let (mutable_royalty_value, mutable_royalty_initialized) =
-            collection_properties::mutable_royalty(properties);
-        let (tokens_burnable_by_collection_owner_value, tokens_burnable_by_collection_owner_initialized) =
-            collection_properties::tokens_burnable_by_collection_owner(properties);
-        let (tokens_transferable_by_collection_owner_value, tokens_transferable_by_collection_owner_initialized) =
-            collection_properties::tokens_transferable_by_collection_owner(properties);
+    /// This function is used to migrate the mutator ref from the old object to the new object (CollectionRefs).
+    /// The creator must be the owner of the collection.
+    public fun migrate_in_collection_properties(
+        migration_signer: &signer,
+        collection_owner: &signer,
+        collection_signer: &signer,
+        collection: Object<Collection>,
+        mutable_description: CollectionProperty,
+        mutable_uri: CollectionProperty,
+        mutable_token_description: CollectionProperty,
+        mutable_token_name: CollectionProperty,
+        mutable_token_properties: CollectionProperty,
+        mutable_token_uri: CollectionProperty,
+        mutable_royalty: CollectionProperty,
+        tokens_burnable_by_collection_owner: CollectionProperty,
+        tokens_transferable_by_collection_owner: CollectionProperty,
+    ) {
+        let migration_object_signer = migration_helper::migration_object_address();
+        assert!(signer::address_of(migration_signer) == migration_object_signer, ENOT_MIGRATION_SIGNER);
+
+        assert_owner(signer::address_of(collection_owner), collection);
+        assert!(
+            !collection_properties_exists(collection),
+            error::invalid_state(ECOLLECTION_PROPERTIES_ALREADY_EXISTS),
+        );
 
         move_to(collection_signer, CollectionProperties {
-            mutable_description: create_property(mutable_description_value, mutable_description_initialized),
-            mutable_uri: create_property(mutable_uri_value, mutable_uri_initialized),
-            mutable_token_description: create_property(
-                mutable_token_description_value,
-                mutable_token_description_initialized,
-            ),
-            mutable_token_name: create_property(mutable_token_name_value, mutable_token_name_initialized),
-            mutable_token_properties: create_property(
-                mutable_token_properties_value,
-                mutable_token_properties_initialized,
-            ),
-            mutable_token_uri: create_property(mutable_token_uri_value, mutable_token_uri_initialized),
-            mutable_royalty: create_property(mutable_royalty_value, mutable_royalty_initialized),
-            tokens_burnable_by_collection_owner: create_property(
-                tokens_burnable_by_collection_owner_value,
-                tokens_burnable_by_collection_owner_initialized,
-            ),
-            tokens_transferable_by_collection_owner: create_property(
-                tokens_transferable_by_collection_owner_value,
-                tokens_transferable_by_collection_owner_initialized,
-            ),
+            mutable_description,
+            mutable_uri,
+            mutable_token_description,
+            mutable_token_name,
+            mutable_token_properties,
+            mutable_token_uri,
+            mutable_royalty,
+            tokens_burnable_by_collection_owner,
+            tokens_transferable_by_collection_owner,
         });
     }
 
-    /// Get extend ref from v1 to v2 contract. The creator must be the owner of the collection.
-
     // ================================== MIGRATE OUT FUNCTIONS ================================== //
 
-    public fun migrate_collection_properties<T: key>(
+    public fun migrate_out_collection_properties<T: key>(
+        migration_signer: &signer,
         collection_owner: &signer,
         obj: Object<T>,
     ): CollectionProperties acquires CollectionProperties {
+        let migration_object_signer = migration_helper::migration_object_address();
+        assert!(signer::address_of(migration_signer) == migration_object_signer, ENOT_MIGRATION_SIGNER);
+
         let properties = *authorized_borrow_mut(collection_owner, obj);
 
         let CollectionProperties {

--- a/token-minter/tests/migration-contracts/token_components_v2.move
+++ b/token-minter/tests/migration-contracts/token_components_v2.move
@@ -12,9 +12,9 @@ module minter_v2::token_components_v2 {
     use aptos_token_objects::property_map;
     use aptos_token_objects::token;
     use aptos_token_objects::token::Token;
+    use minter::migration_helper;
 
-    use minter::collection_properties;
-    use minter::token_components;
+    use minter_v2::collection_properties_v2;
 
     /// Token refs does not exist on this object.
     const ETOKEN_REFS_DOES_NOT_EXIST: u64 = 1;
@@ -30,6 +30,8 @@ module minter_v2::token_components_v2 {
     const ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER: u64 = 6;
     /// The token does not have ExtendRef, so it is not extendable.
     const ETOKEN_NOT_EXTENDABLE: u64 = 7;
+    /// Not the migration object signer.
+    const ENOT_MIGRATION_SIGNER: u64 = 8;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct TokenRefs has key {
@@ -74,7 +76,7 @@ module minter_v2::token_components_v2 {
             is_transferable_by_collection_owner(token),
             error::permission_denied(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER),
         );
-        let transfer_ref = &authorized_borrow_refs(collection_owner, token).transfer_ref;
+        let transfer_ref = &authorized_borrow_refs_mut(collection_owner, token).transfer_ref;
         assert!(option::is_some(transfer_ref), error::not_found(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER));
 
         let linear_transfer_ref = object::generate_linear_transfer_ref(option::borrow(transfer_ref));
@@ -85,7 +87,7 @@ module minter_v2::token_components_v2 {
         assert!(is_transferable_by_collection_owner(token), error::permission_denied(
             ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER
         ));
-        let transfer_ref = &authorized_borrow_refs(collection_owner, token).transfer_ref;
+        let transfer_ref = &authorized_borrow_refs_mut(collection_owner, token).transfer_ref;
         assert!(option::is_some(transfer_ref), error::not_found(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER));
 
         object::disable_ungated_transfer(option::borrow(transfer_ref));
@@ -96,7 +98,7 @@ module minter_v2::token_components_v2 {
             is_transferable_by_collection_owner(token), error::permission_denied(
                 ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER
             ));
-        let transfer_ref = &authorized_borrow_refs(collection_owner, token).transfer_ref;
+        let transfer_ref = &authorized_borrow_refs_mut(collection_owner, token).transfer_ref;
         assert!(option::is_some(transfer_ref), error::not_found(ETOKEN_NOT_TRANSFERABLE_BY_COLLECTION_OWNER));
 
         object::enable_ungated_transfer(option::borrow(transfer_ref));
@@ -108,7 +110,7 @@ module minter_v2::token_components_v2 {
         description: String,
     ) acquires TokenRefs {
         assert!(is_mutable_description(token), error::permission_denied(EFIELD_NOT_MUTABLE));
-        let mutator_ref = &authorized_borrow_refs(collection_owner, token).mutator_ref;
+        let mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).mutator_ref;
         assert!(option::is_some(mutator_ref), error::not_found(EFIELD_NOT_MUTABLE));
 
         token::set_description(option::borrow(mutator_ref), description);
@@ -116,7 +118,7 @@ module minter_v2::token_components_v2 {
 
     public fun set_name(collection_owner: &signer, token: Object<Token>, name: String) acquires TokenRefs {
         assert!(is_mutable_name(token), error::permission_denied(EFIELD_NOT_MUTABLE));
-        let mutator_ref = &authorized_borrow_refs(collection_owner, token).mutator_ref;
+        let mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).mutator_ref;
         assert!(option::is_some(mutator_ref), error::not_found(EFIELD_NOT_MUTABLE));
 
         token::set_name(option::borrow(mutator_ref), name);
@@ -124,7 +126,7 @@ module minter_v2::token_components_v2 {
 
     public fun set_uri(collection_owner: &signer, token: Object<Token>, uri: String) acquires TokenRefs {
         assert!(is_mutable_uri(token), error::permission_denied(EFIELD_NOT_MUTABLE));
-        let mutator_ref = &authorized_borrow_refs(collection_owner, token).mutator_ref;
+        let mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).mutator_ref;
         assert!(option::is_some(mutator_ref), error::not_found(EFIELD_NOT_MUTABLE));
 
         token::set_uri(option::borrow(mutator_ref), uri);
@@ -138,7 +140,7 @@ module minter_v2::token_components_v2 {
         value: vector<u8>,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::add(option::borrow(property_mutator_ref), key, type, value);
@@ -151,7 +153,7 @@ module minter_v2::token_components_v2 {
         value: V,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::add_typed(option::borrow(property_mutator_ref), key, value);
@@ -159,7 +161,7 @@ module minter_v2::token_components_v2 {
 
     public fun remove_property(collection_owner: &signer, token: Object<Token>, key: String) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::remove(option::borrow(property_mutator_ref), &key);
@@ -173,7 +175,7 @@ module minter_v2::token_components_v2 {
         value: vector<u8>,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::update(option::borrow(property_mutator_ref), &key, type, value);
@@ -186,20 +188,19 @@ module minter_v2::token_components_v2 {
         value: V,
     ) acquires TokenRefs {
         assert!(are_properties_mutable(token), error::permission_denied(EPROPERTIES_NOT_MUTABLE));
-        let property_mutator_ref = &authorized_borrow_refs(collection_owner, token).property_mutator_ref;
+        let property_mutator_ref = &authorized_borrow_refs_mut(collection_owner, token).property_mutator_ref;
         assert!(option::is_some(property_mutator_ref), error::not_found(EPROPERTIES_NOT_MUTABLE));
 
         property_map::update_typed(option::borrow(property_mutator_ref), &key, value);
     }
 
     /// Allow borrowing the `TokenRefs` resource if the `collection_owner` owns the token's collection.
-    inline fun authorized_borrow_refs(collection_owner: &signer, token: Object<Token>): &TokenRefs {
+    inline fun authorized_borrow_refs_mut(collection_owner: &signer, token: Object<Token>): &mut TokenRefs {
         assert_token_collection_owner(signer::address_of(collection_owner), token);
-
         let token_address = object::object_address(&token);
         assert!(token_refs_exist(token_address), error::not_found(ETOKEN_REFS_DOES_NOT_EXIST));
 
-        borrow_global<TokenRefs>(token_address)
+        borrow_global_mut<TokenRefs>(token_address)
     }
 
     fun assert_token_collection_owner(collection_owner: address, token: Object<Token>) {
@@ -235,7 +236,7 @@ module minter_v2::token_components_v2 {
     #[view]
     /// Can only be called if the `collection_owner` is the owner of the collection the `token` belongs to.
     public fun token_object_signer(collection_owner: &signer, token: Object<Token>): signer acquires TokenRefs {
-        let extend_ref = &authorized_borrow_refs(collection_owner, token).extend_ref;
+        let extend_ref = &authorized_borrow_refs_mut(collection_owner, token).extend_ref;
         assert!(option::is_some(extend_ref), ETOKEN_NOT_EXTENDABLE);
 
         object::generate_signer_for_extending(option::borrow(extend_ref))
@@ -248,32 +249,32 @@ module minter_v2::token_components_v2 {
 
     #[view]
     public fun are_properties_mutable(token: Object<Token>): bool {
-        collection_properties::is_mutable_token_properties(token::collection_object(token))
+        collection_properties_v2::is_mutable_token_properties(token::collection_object(token))
     }
 
     #[view]
     public fun is_burnable(token: Object<Token>): bool {
-        collection_properties::is_tokens_burnable_by_collection_owner(token::collection_object(token))
+        collection_properties_v2::is_tokens_burnable_by_collection_owner(token::collection_object(token))
     }
 
     #[view]
     public fun is_transferable_by_collection_owner(token: Object<Token>): bool {
-        collection_properties::is_tokens_transferable_by_collection_owner(token::collection_object(token))
+        collection_properties_v2::is_tokens_transferable_by_collection_owner(token::collection_object(token))
     }
 
     #[view]
     public fun is_mutable_description(token: Object<Token>): bool {
-        collection_properties::is_mutable_token_description(token::collection_object(token))
+        collection_properties_v2::is_mutable_token_description(token::collection_object(token))
     }
 
     #[view]
     public fun is_mutable_name(token: Object<Token>): bool {
-        collection_properties::is_mutable_token_name(token::collection_object(token))
+        collection_properties_v2::is_mutable_token_name(token::collection_object(token))
     }
 
     #[view]
     public fun is_mutable_uri(token: Object<Token>): bool {
-        collection_properties::is_mutable_token_uri(token::collection_object(token))
+        collection_properties_v2::is_mutable_token_uri(token::collection_object(token))
     }
 
     // ================================== MIGRATE IN FUNCTIONS ================================== //
@@ -281,169 +282,198 @@ module minter_v2::token_components_v2 {
     /// Migration function used for migrating the refs from one object to another.
     /// This is called when the contract has been upgraded to a new address and version.
     /// This function is used to migrate the refs from the old object to the new object.
+    ///
+    /// To migrate in to the new contract, the `ExtendRef` must be present as the `ExtendRef`
+    /// is used to generate the token object signer.
 
-    /// Get extend ref from v1 to v2 contract. The collection_owner must be the owner of the token's collection.
-    public fun migrate_v1_extend_ref_to_v2(collection_owner: &signer, token: Object<Token>) acquires TokenRefs {
-        let token_signer = &token_components::token_object_signer(collection_owner, token);
-        let token_address = signer::address_of(token_signer);
-        let extend_ref = token_components::migrate_extend_ref(collection_owner, token);
+    /// This function is used to migrate the mutator ref from the old object to the new object (TokenRefs).
+    /// The collection_owner must be the owner of the token's collection.
+    public fun migrate_in_extend_ref(
+        migration_signer: &signer,
+        collection_owner: &signer,
+        token_signer: &signer,
+        token: Object<Token>,
+        extend_ref: Option<object::ExtendRef>,
+    ) acquires TokenRefs {
+        assert_migration_object_signer(migration_signer);
+        assert_token_collection_owner(signer::address_of(collection_owner), token);
 
+        let token_address = object::object_address(&token);
         if (!token_refs_exist(token_address)) {
-            move_to(token_signer, TokenRefs {
-                extend_ref,
-                burn_ref: option::none(),
-                transfer_ref: option::none(),
-                mutator_ref: option::none(),
-                property_mutator_ref: option::none(),
-            });
+            init_token_refs(token_signer, extend_ref, option::none(), option::none(), option::none(), option::none());
         } else {
             borrow_global_mut<TokenRefs>(token_address).extend_ref = extend_ref;
-        }
+        };
     }
 
-    /// Get burn ref from v1 to v2 contract. The collection_owner must be the owner of the token's collection.
-    public fun migrate_v1_burn_ref_to_v2(collection_owner: &signer, collection: Object<Token>) acquires TokenRefs {
-        let token_signer = &token_components::token_object_signer(collection_owner, collection);
-        let token_address = signer::address_of(token_signer);
-        let burn_ref = token_components::migrate_burn_ref(collection_owner, collection);
+    /// This function is used to migrate the burn ref from the old object to the new object (TokenRefs).
+    /// The collection_owner must be the owner of the token's collection.
+    public fun migrate_in_burn_ref(
+        migration_signer: &signer,
+        collection_owner: &signer,
+        token_signer: &signer,
+        token: Object<Token>,
+        burn_ref: Option<token::BurnRef>,
+    ) acquires TokenRefs {
+        assert_migration_object_signer(migration_signer);
+        assert_token_collection_owner(signer::address_of(collection_owner), token);
 
+        let token_address = object::object_address(&token);
         if (!token_refs_exist(token_address)) {
-            move_to(token_signer, TokenRefs {
-                extend_ref: option::none(),
-                burn_ref,
-                transfer_ref: option::none(),
-                mutator_ref: option::none(),
-                property_mutator_ref: option::none(),
-            });
+            init_token_refs(token_signer, option::none(), burn_ref, option::none(), option::none(), option::none());
         } else {
             borrow_global_mut<TokenRefs>(token_address).burn_ref = burn_ref;
-        }
+        };
     }
 
-    /// Get transfer ref from v1 to v2 contract. The collection_owner must be the owner of the token's collection.
-    public fun migrate_v1_transfer_ref_to_v2(collection_owner: &signer, collection: Object<Token>) acquires TokenRefs {
-        let token_signer = &token_components::token_object_signer(collection_owner, collection);
-        let token_address = signer::address_of(token_signer);
-        let transfer_ref = token_components::migrate_transfer_ref(collection_owner, collection);
-
-        if (!token_refs_exist(token_address)) {
-            move_to(token_signer, TokenRefs {
-                extend_ref: option::none(),
-                burn_ref: option::none(),
-                transfer_ref,
-                mutator_ref: option::none(),
-                property_mutator_ref: option::none(),
-            });
-        } else {
-            borrow_global_mut<TokenRefs>(token_address).transfer_ref = transfer_ref
-        }
-    }
-
-    /// Get mutator ref from v1 to v2 contract. The collection_owner must be the owner of the token's collection.
-    public fun migrate_v1_mutator_ref_to_v2(collection_owner: &signer, collection: Object<Token>) acquires TokenRefs {
-        let token_signer = &token_components::token_object_signer(collection_owner, collection);
-        let token_address = signer::address_of(token_signer);
-        let mutator_ref = token_components::migrate_mutator_ref(collection_owner, collection);
-
-        if (!token_refs_exist(token_address)) {
-            move_to(token_signer, TokenRefs {
-                extend_ref: option::none(),
-                burn_ref: option::none(),
-                transfer_ref: option::none(),
-                mutator_ref,
-                property_mutator_ref: option::none(),
-            });
-        } else {
-            borrow_global_mut<TokenRefs>(token_address).mutator_ref = mutator_ref
-        }
-    }
-
-    /// Get property mutator ref from v1 to v2 contract. The collection_owner must be the owner of the token's collection.
-    public fun migrate_v1_property_mutator_ref_to_v2(
+    /// This function is used to migrate the transfer ref from the old object to the new object (TokenRefs).
+    /// The collection_owner must be the owner of the token's collection.
+    public fun migrate_in_transfer_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
-        collection: Object<Token>
+        token_signer: &signer,
+        token: Object<Token>,
+        transfer_ref: Option<object::TransferRef>,
     ) acquires TokenRefs {
-        let token_signer = &token_components::token_object_signer(collection_owner, collection);
-        let token_address = signer::address_of(token_signer);
-        let property_mutator_ref = token_components::migrate_property_mutator_ref(collection_owner, collection);
+        assert_migration_object_signer(migration_signer);
+        assert_token_collection_owner(signer::address_of(collection_owner), token);
 
+        let token_address = object::object_address(&token);
         if (!token_refs_exist(token_address)) {
-            move_to(token_signer, TokenRefs {
-                extend_ref: option::none(),
-                burn_ref: option::none(),
-                transfer_ref: option::none(),
-                mutator_ref: option::none(),
-                property_mutator_ref,
-            });
+            init_token_refs(token_signer, option::none(), option::none(), transfer_ref, option::none(), option::none());
         } else {
-            borrow_global_mut<TokenRefs>(token_address).property_mutator_ref = property_mutator_ref
-        }
+            borrow_global_mut<TokenRefs>(token_address).transfer_ref = transfer_ref;
+        };
+    }
+
+    /// This function is used to migrate the mutator ref from the old object to the new object (TokenRefs).
+    /// The collection_owner must be the owner of the token's collection.
+    public fun migrate_in_mutator_ref(
+        migration_signer: &signer,
+        collection_owner: &signer,
+        token_signer: &signer,
+        token: Object<Token>,
+        mutator_ref: Option<token::MutatorRef>,
+    ) acquires TokenRefs {
+        assert_migration_object_signer(migration_signer);
+        assert_token_collection_owner(signer::address_of(collection_owner), token);
+
+        let token_address = object::object_address(&token);
+        if (!token_refs_exist(token_address)) {
+            init_token_refs(token_signer, option::none(), option::none(), option::none(), mutator_ref, option::none());
+        } else {
+            borrow_global_mut<TokenRefs>(token_address).mutator_ref = mutator_ref;
+        };
+    }
+
+    /// This function is used to migrate the property mutator ref from the old object to the new object (TokenRefs).
+    /// The collection_owner must be the owner of the token's collection.
+    public fun migrate_in_property_mutator_ref(
+        migration_signer: &signer,
+        collection_owner: &signer,
+        token_signer: &signer,
+        token: Object<Token>,
+        property_mutator_ref: Option<property_map::MutatorRef>,
+    ) acquires TokenRefs {
+        assert_migration_object_signer(migration_signer);
+        assert_token_collection_owner(signer::address_of(collection_owner), token);
+
+        let token_address = object::object_address(&token);
+        if (!token_refs_exist(token_address)) {
+            init_token_refs(
+                token_signer,
+                option::none(),
+                option::none(),
+                option::none(),
+                option::none(),
+                property_mutator_ref
+            );
+        } else {
+            borrow_global_mut<TokenRefs>(token_address).property_mutator_ref = property_mutator_ref;
+        };
+    }
+
+    fun init_token_refs(
+        token_object_signer: &signer,
+        extend_ref: Option<object::ExtendRef>,
+        burn_ref: Option<token::BurnRef>,
+        transfer_ref: Option<object::TransferRef>,
+        mutator_ref: Option<token::MutatorRef>,
+        property_mutator_ref: Option<property_map::MutatorRef>,
+    ) {
+        move_to(token_object_signer, TokenRefs {
+            extend_ref,
+            burn_ref,
+            transfer_ref,
+            mutator_ref,
+            property_mutator_ref,
+        });
     }
 
     // ================================== MIGRATE OUT FUNCTIONS ================================== //
 
-    public fun migrate_extend_ref(
+    public fun migrate_out_extend_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<object::ExtendRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let extend_ref = extract_ref_if_present(&mut refs.extend_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         extend_ref
     }
 
-    public fun migrate_burn_ref(
+    public fun migrate_out_burn_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<token::BurnRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let burn_ref = extract_ref_if_present(&mut refs.burn_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         burn_ref
     }
 
-    public fun migrate_transfer_ref(
+    public fun migrate_out_transfer_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<object::TransferRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let transfer_ref = extract_ref_if_present(&mut refs.transfer_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         transfer_ref
     }
 
-    public fun migrate_mutator_ref(
+    public fun migrate_out_mutator_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<token::MutatorRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let mutator_ref = extract_ref_if_present(&mut refs.mutator_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         mutator_ref
     }
 
-    public fun migrate_property_mutator_ref(
+    public fun migrate_out_property_mutator_ref(
+        migration_signer: &signer,
         collection_owner: &signer,
         token: Object<Token>,
     ): Option<property_map::MutatorRef> acquires TokenRefs {
-        assert_token_collection_owner(signer::address_of(collection_owner), token);
-        let token_address = assert_token_refs_exist(token);
+        assert_migration_object_signer(migration_signer);
 
-        let refs = borrow_global_mut<TokenRefs>(token_address);
+        let refs = authorized_borrow_refs_mut(collection_owner, token);
         let property_mutator_ref = extract_ref_if_present(&mut refs.property_mutator_ref);
-        destroy_token_refs_if_all_refs_migrated(refs, token_address);
+        destroy_token_refs_if_all_refs_migrated(refs, object::object_address(&token));
         property_mutator_ref
     }
 
@@ -455,7 +485,10 @@ module minter_v2::token_components_v2 {
         }
     }
 
-    inline fun destroy_token_refs_if_all_refs_migrated(token_refs: &mut TokenRefs, token_address: address) acquires TokenRefs {
+    inline fun destroy_token_refs_if_all_refs_migrated(
+        token_refs: &mut TokenRefs,
+        token_address: address
+    ) acquires TokenRefs {
         if (option::is_none(&token_refs.extend_ref)
             && option::is_none(&token_refs.burn_ref)
             && option::is_none(&token_refs.transfer_ref)
@@ -478,5 +511,10 @@ module minter_v2::token_components_v2 {
             error::not_found(ETOKEN_REFS_DOES_NOT_EXIST)
         );
         token_address
+    }
+
+    fun assert_migration_object_signer(migration_signer: &signer) {
+        let migration_object_signer = migration_helper::migration_object_address();
+        assert!(signer::address_of(migration_signer) == migration_object_signer, ENOT_MIGRATION_SIGNER);
     }
 }

--- a/token-minter/tests/modules/collection_properties_tests.move
+++ b/token-minter/tests/modules/collection_properties_tests.move
@@ -162,6 +162,6 @@ module minter::collection_properties_tests {
     }
 
     fun default_properties(value: bool): CollectionProperties {
-        collection_properties::create_properties(value, value, value, value, value, value, value, value, value)
+        collection_properties::create_uninitialized_properties(value, value, value, value, value, value, value, value, value)
     }
 }


### PR DESCRIPTION
Add in `Migration` package to handle migrations from version X to version Y.
- This is needed to decouple contract X from contract Y. 

Spoke with @movekevin , this is an appropriate way of decoupling contracts during migration, and having the migration contract object be responsible for calling the migrate functions in each contract.
- Anyone can call the migration contract, which migrates these resources to the updated contract:
  - `CollectionRefs`
  - `CollectionProperties`
  - `TokenRefs`

## Testing
Deployed 3 contracts to testnet:
1. TokenMinter contract: https://explorer.aptoslabs.com/account/0x186be62b3c3e54fa01fcc4d1e147372ab24cf6dd4ec09bbf6d570f094f7f94fe/modules/code/coin_payment?network=testnet
2. TokenMinterV2 contract: https://explorer.aptoslabs.com/account/0xf0995d360365587c500cc171d1416bad10a331b9c71871a1aec5f2c37ff43124/modules/code/coin_payment?network=testnet
3. Migration contract: https://explorer.aptoslabs.com/account/0xd3cb5491ef963455c6a3dab9ec8e8d49eae0cd76b2863813635977c788b07131/modules/code/migration?network=testnet