### PR TITLE
Refactoring config so we don't need to specify minter_v2 address

### DIFF
--- a/airdrop-machine/Move.toml
+++ b/airdrop-machine/Move.toml
@@ -9,8 +9,6 @@ airdrop_machine = "_"
 [dev-addresses]
 airdrop_machine = "0x123"
 minter = "0x456"
-minter_v2 = "0x457"
-migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/example-composable/Move.toml
+++ b/example-composable/Move.toml
@@ -9,8 +9,6 @@ example_composable = "_"
 [dev-addresses]
 example_composable = "0x12345"
 minter = "0x1c3e5574728c3d0d544f5679229fac153c5f7d78b323751b41860c5ffbb21cfd"
-minter_v2 = "0x456"
-migration = "0x789"
 
 [dependencies.TokenMinter]
 local = "../token-minter"

--- a/example-ownership/Move.toml
+++ b/example-ownership/Move.toml
@@ -9,8 +9,6 @@ example_ownership = "_"
 [dev-addresses]
 example_ownership = "0x123"
 minter = "0xb04204ddbcf130b6d1accfdd2e9593275cb6d4777d70ebd41a4799c007c55a2b"
-minter_v2 = "0x456"
-migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/ez-launch/Move.toml
+++ b/ez-launch/Move.toml
@@ -9,8 +9,6 @@ ez_launch = "_"
 [dev-addresses]
 ez_launch = "0x123"
 minter = "0x456"
-minter_v2 = "0x457"
-migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/launchpad/Move.toml
+++ b/launchpad/Move.toml
@@ -11,8 +11,6 @@ launchpad_admin = "_"
 launchpad = "0x123"
 minter = "0xb04204ddbcf130b6d1accfdd2e9593275cb6d4777d70ebd41a4799c007c55a2b"
 launchpad_admin = "0x678"
-minter_v2 = "0x456"
-migration = "0x789"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/migration/Move.toml
+++ b/migration/Move.toml
@@ -9,8 +9,6 @@ migration = "_"
 
 [dev-addresses]
 minter = "0x123"
-minter_v2 = "0x456"
-migration = "0x789"
 
 [dependencies.TokenMinter]
 local = "../token-minter"

--- a/token-minter/Move.toml
+++ b/token-minter/Move.toml
@@ -5,13 +5,13 @@ authors = []
 
 [addresses]
 minter = "_"
-minter_v2 = "_"
-migration = "_"
+migration = "0x111" # Will replace when we have an address responsible for migrations.
+# Mock addresses for testing.
+minter_v2 = "0x999"
 
 [dev-addresses]
 minter = "0x123"
-minter_v2 = "0x456"
-migration = "0x789"
+migration = "0x111"
 
 [dependencies.AptosFramework]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/token-minter/tests/migration-contracts/collection_components_v2.move
+++ b/token-minter/tests/migration-contracts/collection_components_v2.move
@@ -1,3 +1,4 @@
+#[test_only]
 /// This module is an example of the v2 contract upgrade for `collection_components.move`.
 module minter_v2::collection_components_v2 {
 

--- a/token-minter/tests/migration-contracts/collection_properties_v2.move
+++ b/token-minter/tests/migration-contracts/collection_properties_v2.move
@@ -1,3 +1,4 @@
+#[test_only]
 module minter_v2::collection_properties_v2 {
 
     use std::error;

--- a/token-minter/tests/migration-contracts/token_components_v2.move
+++ b/token-minter/tests/migration-contracts/token_components_v2.move
@@ -1,3 +1,4 @@
+#[test_only]
 /// This module is an example of the v2 contract upgrade for `token_components.move`.
 module minter_v2::token_components_v2 {
 


### PR DESCRIPTION
Removing the need for specifying address `minter_v2` as this is only used in tests.