### PR TITLE
Refactor mint stage to use vector vs simple map

### DIFF
--- a/ez-launch/tests/ez_launch_with_stages_tests.move
+++ b/ez-launch/tests/ez_launch_with_stages_tests.move
@@ -44,13 +44,14 @@ module ez_launch::ez_launch_with_stages_tests {
         let stage_category = utf8(b"Public Sale");
         let start_time = now - 3600;
         let end_time = now + 7200;
-        let no_allowlist_max_mint = option::none();
-        ez_launch_with_stages::add_stage(creator, ez_launch_config_obj, stage_category, start_time, end_time, no_allowlist_max_mint);
+        ez_launch_with_stages::add_stage(creator, ez_launch_config_obj, stage_category, start_time, end_time);
 
-        let stages = mint_stage::stages(ez_launch_config_obj);
+        let collection = ez_launch_with_stages::collection(ez_launch_config_obj);
+        let stages = mint_stage::stages(collection);
         assert!(vector::contains(&stages, &stage_category), 1);
 
-        ez_launch_with_stages::add_to_allowlist(creator, ez_launch_config_obj, stage_category, vector[user_addr], vector[1]);
+        let stage_index = mint_stage::find_mint_stage_index_by_name(collection, stage_category);
+        ez_launch_with_stages::add_to_allowlist(creator, ez_launch_config_obj, stage_index, vector[user_addr], vector[1]);
 
         let mint_fee = 100;
         ez_launch_with_stages::add_fee(creator, ez_launch_config_obj, mint_fee, creator_addr, stage_category);
@@ -79,16 +80,17 @@ module ez_launch::ez_launch_with_stages_tests {
         let stage_category = utf8(b"Presale");
         let start_time = now + 3600;
         let end_time = now + 7200;
-        let no_allowlist_max_mint = option::none();
-        ez_launch_with_stages::add_stage(creator, ez_launch_config_obj, stage_category, start_time, end_time, no_allowlist_max_mint);
+        ez_launch_with_stages::add_stage(creator, ez_launch_config_obj, stage_category, start_time, end_time);
 
         let user_address = signer::address_of(user);
-        ez_launch_with_stages::add_to_allowlist(creator, ez_launch_config_obj, stage_category, vector[user_address], vector[1]);
+        let collection = ez_launch_with_stages::collection(ez_launch_config_obj);
+        let stage_index = mint_stage::find_mint_stage_index_by_name(collection, stage_category);
+        ez_launch_with_stages::add_to_allowlist(creator, ez_launch_config_obj, stage_index, vector[user_address], vector[1]);
 
-        assert!(mint_stage::is_allowlisted(ez_launch_config_obj, stage_category, user_address), 1);
+        assert!(mint_stage::is_allowlisted(collection, stage_index, user_address), 1);
 
-        ez_launch_with_stages::remove_from_allowlist(creator, ez_launch_config_obj, stage_category, vector[user_address]);
-        assert!(!mint_stage::is_allowlisted(ez_launch_config_obj, stage_category, user_address), 1);
+        ez_launch_with_stages::remove_from_allowlist(creator, ez_launch_config_obj, stage_index, vector[user_address]);
+        assert!(!mint_stage::is_allowlisted(collection, stage_index, user_address), 1);
     }
 
     #[test(creator = @0x1, user = @0x2, aptos_framework = @0x1)]
@@ -113,8 +115,7 @@ module ez_launch::ez_launch_with_stages_tests {
         let stage_category = utf8(b"Public Sale");
         let start_time = now + 3600;
         let end_time = now + 7200;
-        let no_allowlist_max_mint = option::some(2);
-        ez_launch_with_stages::add_stage(creator, ez_launch_config_obj, stage_category, start_time, end_time, no_allowlist_max_mint);
+        ez_launch_with_stages::add_stage(creator, ez_launch_config_obj, stage_category, start_time, end_time);
 
         // Add fee
         let mint_fee = 100;

--- a/token-minter/sources/modules/mint_stage.move
+++ b/token-minter/sources/modules/mint_stage.move
@@ -6,13 +6,13 @@ module minter::mint_stage {
     use std::signer;
     use std::string::String;
     use std::vector;
-    use aptos_std::simple_map;
-    use aptos_std::simple_map::SimpleMap;
     use aptos_std::smart_table::{Self, SmartTable};
     use aptos_framework::event;
     use aptos_framework::object;
-    use aptos_framework::object::{ConstructorRef, Object};
+    use aptos_framework::object::{ConstructorRef, DeleteRef, ExtendRef, Object};
     use aptos_framework::timestamp;
+
+    use aptos_token_objects::collection::Collection;
 
     /// The mint stage start time must be less than the mint stage end time.
     const EINVALID_START_TIME: u64 = 1;
@@ -36,369 +36,559 @@ module minter::mint_stage {
     const EINSUFFICIENT_MAX_PER_USER_BALANCE: u64 = 10;
     /// The amount of tokens should be greater than zero.
     const EINSUFFICIENT_AMOUNT: u64 = 11;
-
+    /// Allowlist does not exist on the collection
+    const EALLOWLIST_DOES_NOT_EXIST: u64 = 12;
+    /// Public stage with limit does not exist on the collection
+    const EPUBLIC_STAGE_WITH_LIMIT_DOES_NOT_EXIST: u64 = 13;
+    /// The mint stage does not exist on the collection
+    const EMINT_STAGE_DOES_NOT_EXIST: u64 = 14;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct MintStageData has key {
-        /// stage ("private", "presale", "public", etc.) to mint stage mapping.
-        mint_stages: SimpleMap<String, MintStage>,
-        /// Stages sorted from the earliest start time.
-        stages: vector<String>,
+        mint_stages: vector<Object<MintStage>>,
     }
 
-    struct MintStage has store {
-        /// The start time of the mint stage.
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    struct MintStage has key {
+        name: String,
         start_time: u64,
-        /// The end time of the mint stage.
         end_time: u64,
-        /// Allowlist of addresses with their mint allowance.
-        /// Empty allowlist means there are no restrictions.
-        allowlist: SmartTable<address, u64>,
-        /// If allowlist is empty, then everyone can mint but configurable with an optional max limit.
-        no_allowlist: NoAllowlist,
+        extend_ref: ExtendRef,
+        delete_ref: DeleteRef,
     }
 
-    struct NoAllowlist has store {
-        max_per_user: Option<u64>,
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    struct Allowlist has key {
+        /// Mapping from user address to remaining mint amount
+        mint_allowances: SmartTable<address, u64>,
+    }
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    struct PublicMintStageWithLimit has key {
+        max_per_user: u64,
         user_balances: SmartTable<address, u64>,
     }
 
     #[event]
-    /// Event emitted when a new mint stage is created.
     struct CreateMintStage has drop, store {
         mint_stage_data: Object<MintStageData>,
-        stage: String,
+        mint_stage: Object<MintStage>,
+        name: String,
         start_time: u64,
         end_time: u64,
-        no_allowlist_max_per_user: Option<u64>,
     }
 
     #[event]
-    /// Event emitted when a mint stage is removed.
     struct RemoveMintStage has drop, store {
         mint_stage_data: Object<MintStageData>,
-        stage: String,
+        mint_stage: Object<MintStage>,
+        name: String,
     }
 
-    /// Create a new mint stage with the specified start and end time.
-    /// The `MintStageData` resource is stored under the constructor ref address.
+    #[event]
+    struct UpdateMintStage has drop, store {
+        mint_stage_data: Object<MintStageData>,
+        mint_stage: Object<MintStage>,
+        old_name: String,
+        new_name: String,
+        old_start_time: u64,
+        new_start_time: u64,
+        old_end_time: u64,
+        new_end_time: u64,
+    }
+
     public fun init(
-        constructor_ref: &ConstructorRef,
+        collection_constructor_ref: &ConstructorRef,
+        name: String,
         start_time: u64,
         end_time: u64,
-        stage: String,
-        max_per_user: Option<u64>,
-    ): Object<MintStageData> acquires MintStageData {
-        let object_signer = &object::generate_signer(constructor_ref);
-        create(object_signer, start_time, end_time, stage, max_per_user)
+    ): Object<MintStageData> acquires MintStageData, MintStage {
+        let collection_signer = &object::generate_signer(collection_constructor_ref);
+        create(collection_signer, name, start_time, end_time)
     }
 
-    /// Create a new mint stage with the specified start and end time.
-    /// The `MintStageData` resource is stored under the object signer address.
-    /// This function is used to extend the current object.
     public fun create(
-        object_signer: &signer,
+        collection_signer: &signer,
+        name: String,
         start_time: u64,
         end_time: u64,
-        stage: String,
-        no_allowlist_max_per_user: Option<u64>,
-    ): Object<MintStageData> acquires MintStageData {
+    ): Object<MintStageData> acquires MintStageData, MintStage {
         valid_start_and_end_time(start_time, end_time);
 
-        let object_addr = signer::address_of(object_signer);
-        if (!exists<MintStageData>(object_addr)) {
-            move_to(object_signer, MintStageData {
-                mint_stages: simple_map::new(),
-                stages: vector[],
+        let collection_addr = signer::address_of(collection_signer);
+        if (!exists<MintStageData>(collection_addr)) {
+            move_to(collection_signer, MintStageData {
+                mint_stages: vector[],
             });
         };
 
-        let mint_stage_data = borrow_global_mut<MintStageData>(object_addr);
-        simple_map::add(&mut mint_stage_data.mint_stages, stage, MintStage {
-            start_time,
-            end_time,
-            allowlist: smart_table::new(),
-            no_allowlist: NoAllowlist {
-                max_per_user: no_allowlist_max_per_user,
-                user_balances: smart_table::new(),
-            },
-        });
+        let mint_stage_data = object::address_to_object(collection_addr);
+        let mint_stage = create_mint_stage_object(collection_addr, name, start_time, end_time);
+        add_to_stages(&mut borrow_mut(mint_stage_data).mint_stages, mint_stage);
 
-        add_to_stages(
-            &mut mint_stage_data.stages,
-            stage,
-            start_time,
-            end_time,
-            &mint_stage_data.mint_stages,
-        );
-
-        let mint_stage_data = object::address_to_object(object_addr);
+        let mint_stage_data = object::convert(mint_stage_data);
         event::emit(CreateMintStage {
-            mint_stage_data,
-            stage,
+            mint_stage_data: object::convert(mint_stage_data),
+            mint_stage,
+            name,
             start_time,
             end_time,
-            no_allowlist_max_per_user,
         });
 
         mint_stage_data
     }
 
-    public fun remove_stage<T: key>(owner: &signer, obj: Object<T>, stage: String) acquires MintStageData {
-        let stages = &mut authorized_borrow_mut(owner, obj).mint_stages;
-        assert!(simple_map::contains_key(stages, &stage), error::not_found(ESTAGE_DOES_NOT_EXIST));
+    public fun remove_stage(
+        owner: &signer,
+        collection: Object<Collection>,
+        index: u64,
+    ) acquires MintStageData, MintStage, Allowlist, PublicMintStageWithLimit {
+        let mint_stages = &mut authorized_borrow_mut(owner, collection).mint_stages;
+        let mint_stage_obj = vector::remove(mint_stages, index);
+        let MintStage { name, start_time: _, end_time: _, extend_ref: _, delete_ref } = move_from<MintStage>(
+            object::object_address(&mint_stage_obj)
+        );
 
-        let (_, mint_stage) = simple_map::remove(stages, &stage);
-        let MintStage { start_time: _, end_time: _, allowlist, no_allowlist } = mint_stage;
-        let NoAllowlist { max_per_user: _, user_balances } = no_allowlist;
-        smart_table::destroy(allowlist);
-        smart_table::destroy(user_balances);
+        if (allowlist_exists(mint_stage_obj)) {
+            let Allowlist { mint_allowances } = move_from<Allowlist>(object::object_address(&mint_stage_obj));
+            smart_table::destroy(mint_allowances);
+        } else if (public_stage_with_limit_exists(mint_stage_obj)) {
+            let PublicMintStageWithLimit { max_per_user: _, user_balances } = move_from<PublicMintStageWithLimit>(
+                object::object_address(&mint_stage_obj)
+            );
+            smart_table::destroy(user_balances);
+        };
 
-        event::emit(RemoveMintStage { mint_stage_data: object::convert(obj), stage });
+        object::delete(delete_ref);
+
+        event::emit(RemoveMintStage { mint_stage_data: object::convert(collection), mint_stage: mint_stage_obj, name });
     }
 
-    /// Executes the earliest stage if it is active.
-    /// Returns the stage name if the stage is active and executed, otherwise returns `none`.
-    public fun execute_earliest_stage<T: key>(
+    public fun update_mint_stage(
+        owner: &signer,
+        collection: Object<Collection>,
+        index: u64,
+        new_name: String,
+        new_start_time: u64,
+        new_end_time: u64,
+    ) acquires MintStageData, MintStage {
+        valid_start_and_end_time(new_start_time, new_end_time);
+
+        let mint_stages = &mut authorized_borrow_mut(owner, collection).mint_stages;
+        let mint_stage_obj = vector::remove(mint_stages, index);
+
+        let mint_stage = borrow_mut_mint_stage_from_object(mint_stage_obj);
+        let old_name = mint_stage.name;
+        let old_start_time = mint_stage.start_time;
+        let old_end_time = mint_stage.end_time;
+        mint_stage.name = new_name;
+        mint_stage.start_time = new_start_time;
+        mint_stage.end_time = new_end_time;
+
+        add_to_stages(mint_stages, mint_stage_obj);
+
+        event::emit(UpdateMintStage {
+            mint_stage_data: object::convert(collection),
+            mint_stage: mint_stage_obj,
+            old_name,
+            new_name,
+            old_start_time,
+            new_start_time,
+            old_end_time,
+            new_end_time,
+        });
+    }
+
+    public fun execute_earliest_stage(
         user: &signer,
-        obj: Object<T>,
+        collection: Object<Collection>,
         amount: u64,
-    ): Option<String> acquires MintStageData {
-        let stages = stages(obj);
-        for (i in 0..vector::length(&stages)) {
-            let stage = *vector::borrow(&stages, i);
-            if (is_active(obj, stage)) {
-                assert_active_and_execute(user, obj, stage, amount);
-                return option::some(stage)
+    ): Option<u64> acquires MintStageData, MintStage, Allowlist, PublicMintStageWithLimit {
+        let stages = stages(collection);
+        for (index in 0..vector::length(&stages)) {
+            if (is_active(collection, index)) {
+                assert_active_and_execute(user, collection, index, amount);
+                return option::some(index)
+            } else {
+                // Delete mint stage object if not active
+                let (_, mint_stage_obj) = borrow_mut_mint_stage(collection, index);
+                destroy_mint_stage(mint_stage_obj);
             }
         };
         option::none()
     }
 
-    /// This function is to be called to verify if the user is allowed to mint tokens in the specified stage.
-    /// The stage must be active, and the user must be in the allowlist with enough allowance.
-    /// If allowlist is empty, this means there is no allowlist and only start and end times are verified.
-    public fun assert_active_and_execute<T: key>(
+    public fun assert_active_and_execute(
         user: &signer,
-        obj: Object<T>,
-        stage: String,
+        collection: Object<Collection>,
+        index: u64,
         amount: u64,
-    ) acquires MintStageData {
-        let mint_stage = borrow_mut_mint_stage(obj, stage);
+    ) acquires MintStageData, MintStage, Allowlist, PublicMintStageWithLimit {
+        let (mint_stage, mint_stage_obj) = get_mint_stage(&mut borrow_mut(collection).mint_stages, index);
         let current_time = timestamp::now_seconds();
         assert!(amount > 0, error::invalid_argument(EINSUFFICIENT_AMOUNT));
         assert!(current_time >= mint_stage.start_time, error::invalid_state(EMINT_STAGE_NOT_STARTED));
         assert!(current_time < mint_stage.end_time, error::invalid_state(EMINT_STAGE_ENDED));
 
         let user_addr = signer::address_of(user);
-        // Check if the user is in the allowlist and has enough allowance.
-        // If the allowlist is empty, this means there is no allowlist and everyone can mint.
-        if (smart_table::length(&mint_stage.allowlist) > 0) {
-            let remaining = allowlist_balance_internal(&mint_stage.allowlist, user_addr);
+
+        if (allowlist_exists(mint_stage_obj)) {
+            let allowlist = borrow_mut_allowlist(mint_stage_obj);
+            let remaining = allowlist_balance_internal(&allowlist.mint_allowances, user_addr);
             assert!(
                 remaining >= amount,
                 error::invalid_state(EINSUFFICIENT_ALLOWLIST_BALANCE),
             );
-            smart_table::upsert(&mut mint_stage.allowlist, user_addr, remaining - amount);
-        } else if (option::is_some(&mint_stage.no_allowlist.max_per_user)) {
-            // If the `max_per_user` is set, then check if the user has enough balance.
-            let max_per_user = *option::borrow(&mint_stage.no_allowlist.max_per_user);
+            smart_table::upsert(&mut allowlist.mint_allowances, user_addr, remaining - amount);
+        };
+        if (public_stage_with_limit_exists(mint_stage_obj)) {
+            let public_stage = borrow_mut_public_stage_with_limit(mint_stage_obj);
             let balance = *smart_table::borrow_mut_with_default(
-                &mut mint_stage.no_allowlist.user_balances,
+                &mut public_stage.user_balances,
                 user_addr,
                 0,
             );
             let total_balance = balance + amount;
             assert!(
-                total_balance <= max_per_user,
+                total_balance <= public_stage.max_per_user,
                 error::invalid_state(EINSUFFICIENT_MAX_PER_USER_BALANCE),
             );
-            smart_table::upsert(&mut mint_stage.no_allowlist.user_balances, user_addr, total_balance);
-        }
+            smart_table::upsert(&mut public_stage.user_balances, user_addr, total_balance);
+        };
     }
 
-    public fun set_start_and_end_time<T: key>(
+    public fun set_start_and_end_time(
         owner: &signer,
-        obj: Object<T>,
-        stage: String,
+        collection: Object<Collection>,
+        index: u64,
         start_time: u64,
         end_time: u64,
-    ) acquires MintStageData {
+    ) acquires MintStageData, MintStage {
         valid_start_and_end_time(start_time, end_time);
 
-        let mint_stage = authorized_borrow_mut_mint_stage(owner, obj, stage);
+        let (mint_stage, _) = authorized_borrow_mut_mint_stage(owner, collection, index);
         mint_stage.start_time = start_time;
         mint_stage.end_time = end_time;
     }
 
-    /// Add an address to the allowlist with a specific allowance.
-    /// If the allowlist is not set in the `mint_stage`, it will be created for the mint stage.
-    public fun add_to_allowlist<T: key>(
+    public fun add_to_allowlist(
         owner: &signer,
-        obj: Object<T>,
-        stage: String,
+        collection: Object<Collection>,
+        index: u64,
         addr: address,
         amount: u64
-    ) acquires MintStageData {
-        let mint_stage = authorized_borrow_mut_mint_stage(owner, obj, stage);
-        smart_table::upsert(&mut mint_stage.allowlist, addr, amount);
+    ) acquires MintStageData, MintStage, Allowlist {
+        let (_, mint_stage_obj) = authorized_borrow_mut_mint_stage(owner, collection, index);
+        if (!allowlist_exists(mint_stage_obj)) {
+            move_to(&mint_stage_signer(mint_stage_obj), Allowlist {
+                mint_allowances: smart_table::new(),
+            });
+        };
+        smart_table::upsert(&mut borrow_mut_allowlist(mint_stage_obj).mint_allowances, addr, amount);
     }
 
-    public fun remove_from_allowlist<T: key>(
+    public fun remove_from_allowlist(
         owner: &signer,
-        obj: Object<T>,
-        stage: String,
+        collection: Object<Collection>,
+        index: u64,
         addr: address,
-    ) acquires MintStageData {
-        let mint_stage = authorized_borrow_mut_mint_stage(owner, obj, stage);
-        smart_table::remove(&mut mint_stage.allowlist, addr);
+    ) acquires MintStageData, Allowlist, MintStage {
+        let (_, mint_stage_obj) = authorized_borrow_mut_mint_stage(owner, collection, index);
+        smart_table::remove(&mut borrow_mut_allowlist(mint_stage_obj).mint_allowances, addr);
     }
 
-    public fun remove_everyone_from_allowlist<T: key>(
+    public fun clear_allowlist(
         owner: &signer,
-        obj: Object<T>,
-        stage: String,
-    ) acquires MintStageData {
-        let mint_stage = authorized_borrow_mut_mint_stage(owner, obj, stage);
-        smart_table::clear(&mut mint_stage.allowlist);
+        collection: Object<Collection>,
+        index: u64,
+    ) acquires MintStageData, MintStage, Allowlist {
+        let (_, mint_stage_obj) = authorized_borrow_mut_mint_stage(owner, collection, index);
+        smart_table::clear(&mut borrow_mut_allowlist(mint_stage_obj).mint_allowances);
     }
 
-    public fun set_no_allowlist_max_per_user<T: key>(
+    public fun set_public_stage_max_per_user(
         owner: &signer,
-        obj: Object<T>,
-        stage: String,
-        max_per_user: Option<u64>,
-    ) acquires MintStageData {
-        let mint_stage = authorized_borrow_mut_mint_stage(owner, obj, stage);
-        mint_stage.no_allowlist.max_per_user = max_per_user;
+        collection: Object<Collection>,
+        index: u64,
+        max_per_user: u64,
+    ) acquires MintStageData, MintStage, PublicMintStageWithLimit {
+        let (_, mint_stage_obj) = authorized_borrow_mut_mint_stage(owner, collection, index);
+        if (!public_stage_with_limit_exists(mint_stage_obj)) {
+            move_to(&mint_stage_signer(mint_stage_obj), PublicMintStageWithLimit {
+                max_per_user,
+                user_balances: smart_table::new(),
+            });
+        } else {
+            borrow_mut_public_stage_with_limit(mint_stage_obj).max_per_user = max_per_user;
+        }
     }
 
-    public fun destroy<T: key>(owner: &signer, obj: Object<T>) acquires MintStageData {
-        assert_owner(owner, obj);
+    public fun destroy(
+        owner: &signer,
+        collection: Object<Collection>,
+    ) acquires MintStageData, MintStage, Allowlist, PublicMintStageWithLimit {
+        assert_owner(owner, collection);
 
         let MintStageData {
             mint_stages,
-            stages: _,
-        } = move_from<MintStageData>(object::object_address(&obj));
+        } = move_from<MintStageData>(object::object_address(&collection));
 
-        simple_map::destroy(mint_stages, |_stage| {}, |mint_stage| {
-            let MintStage { start_time: _, end_time: _, allowlist, no_allowlist } = mint_stage;
-            let NoAllowlist { max_per_user: _, user_balances } = no_allowlist;
-            smart_table::destroy(allowlist);
-            smart_table::destroy(user_balances);
+        vector::destroy(mint_stages, |mint_stage| {
+            destroy_mint_stage(mint_stage);
         });
+    }
+
+    inline fun destroy_mint_stage(mint_stage: Object<MintStage>) acquires MintStage {
+        let mint_stage_addr = object::object_address(&mint_stage);
+        let MintStage { name: _, start_time: _, end_time: _, extend_ref: _, delete_ref } = move_from<MintStage>(
+            mint_stage_addr
+        );
+        if (allowlist_exists(mint_stage)) {
+            let Allowlist { mint_allowances } = move_from<Allowlist>(mint_stage_addr);
+            smart_table::destroy(mint_allowances);
+        };
+        if (public_stage_with_limit_exists(mint_stage)) {
+            let PublicMintStageWithLimit { max_per_user: _, user_balances } = move_from<PublicMintStageWithLimit>(
+                mint_stage_addr,
+            );
+            smart_table::destroy(user_balances);
+        };
+        object::delete(delete_ref);
     }
 
     // ====================================== View Functions ====================================== //
 
     #[view]
-    public fun is_active<T: key>(obj: Object<T>, stage: String): bool acquires MintStageData {
-        let mint_stage = borrow_mint_stage(obj, stage);
+    public fun is_active(collection: Object<Collection>, index: u64): bool acquires MintStageData, MintStage {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
         let current_time = timestamp::now_seconds();
-        current_time >= mint_stage.start_time && current_time < mint_stage.end_time
+        current_time >= mint_stage_start_time(mint_stage_obj) && current_time < mint_stage_end_time(mint_stage_obj)
     }
 
     #[view]
-    public fun allowlist_balance<T: key>(
-        obj: Object<T>,
-        stage: String,
+    public fun allowlist_balance(
+        collection: Object<Collection>,
+        index: u64,
         addr: address,
-    ): u64 acquires MintStageData {
-        let mint_stage = borrow_mint_stage(obj, stage);
-        allowlist_balance_internal(&mint_stage.allowlist, addr)
+    ): u64 acquires MintStageData, MintStage, Allowlist {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        allowlist_balance_internal(&borrow_allowlist(mint_stage_obj).mint_allowances, addr)
     }
 
     #[view]
-    public fun is_allowlisted<T: key>(
-        obj: Object<T>,
-        stage: String,
+    public fun is_allowlisted(
+        collection: Object<Collection>,
+        index: u64,
         addr: address
-    ): bool acquires MintStageData {
-        let mint_stage = simple_map::borrow(&borrow(obj).mint_stages, &stage);
-        smart_table::contains(&mint_stage.allowlist, addr)
+    ): bool acquires MintStageData, MintStage, Allowlist {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        smart_table::contains(&borrow_allowlist(mint_stage_obj).mint_allowances, addr)
     }
 
     #[view]
-    public fun allowlist_count<T: key>(obj: Object<T>, stage: String): u64 acquires MintStageData {
-        let mint_stage = borrow_mint_stage(obj, stage);
-        smart_table::length(&mint_stage.allowlist)
+    public fun allowlist_count(
+        collection: Object<Collection>,
+        index: u64
+    ): u64 acquires MintStageData, MintStage, Allowlist {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        smart_table::length(&borrow_allowlist(mint_stage_obj).mint_allowances)
     }
 
     #[view]
-    public fun is_stage_allowlisted<T: key>(obj: Object<T>, stage: String): bool acquires MintStageData {
-        let mint_stage = simple_map::borrow(&borrow(obj).mint_stages, &stage);
-        smart_table::length(&mint_stage.allowlist) > 0
+    public fun is_stage_allowlisted(
+        collection: Object<Collection>,
+        index: u64
+    ): bool acquires MintStageData, MintStage {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        allowlist_exists(mint_stage_obj)
     }
 
     #[view]
-    public fun start_time<T: key>(obj: Object<T>, stage: String): u64 acquires MintStageData {
-        borrow_mint_stage(obj, stage).start_time
+    public fun start_time(collection: Object<Collection>, index: u64): u64 acquires MintStageData, MintStage {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        mint_stage_start_time(mint_stage_obj)
     }
 
     #[view]
-    public fun end_time<T: key>(obj: Object<T>, stage: String): u64 acquires MintStageData {
-        borrow_mint_stage(obj, stage).end_time
+    public fun end_time(collection: Object<Collection>, index: u64): u64 acquires MintStageData, MintStage {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        mint_stage_end_time(mint_stage_obj)
     }
 
     #[view]
     /// This function returns the categories sorted from the earliest start time.
-    public fun stages<T: key>(obj: Object<T>): vector<String> acquires MintStageData {
-        borrow(obj).stages
+    public fun stages(collection: Object<Collection>): vector<String> acquires MintStageData, MintStage {
+        vector::map_ref(&borrow(collection).mint_stages, |mint_stage| {
+            let mint_stage: &Object<MintStage> = mint_stage;
+            mint_stage_name(*mint_stage)
+        })
     }
 
     #[view]
-    public fun mint_stage_data_exists(obj_addr: address): bool {
-        exists<MintStageData>(obj_addr)
+    public fun mint_stage_data_exists(collection: Object<Collection>): bool {
+        exists<MintStageData>(object::object_address(&collection))
     }
 
     #[view]
-    public fun no_allowlist_max_per_user<T: key>(
-        obj: Object<T>,
-        stage: String,
-    ): Option<u64> acquires MintStageData {
-        let mint_stage = borrow_mint_stage(obj, stage);
-        mint_stage.no_allowlist.max_per_user
-    }
-
-    #[view]
-    public fun user_balance_in_no_allowlist<T: key>(
-        obj: Object<T>,
-        stage: String,
+    public fun public_stage_with_limit_user_balance(
+        collection: Object<Collection>,
+        index: u64,
         user: address,
-    ): Option<u64> acquires MintStageData {
-        let mint_stage = borrow_mint_stage(obj, stage);
-        if (smart_table::contains(&mint_stage.no_allowlist.user_balances, user)) {
-            let max_per_user = *option::borrow(&mint_stage.no_allowlist.max_per_user);
-            let balance = *smart_table::borrow(&mint_stage.no_allowlist.user_balances, user);
-            option::some(max_per_user - balance)
+    ): u64 acquires MintStageData, MintStage, PublicMintStageWithLimit {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        let public_stage = borrow_public_stage_with_limit(mint_stage_obj);
+        if (smart_table::contains(&public_stage.user_balances, user)) {
+            let user_balance = *smart_table::borrow(&public_stage.user_balances, user);
+            public_stage.max_per_user - user_balance
         } else {
-            mint_stage.no_allowlist.max_per_user
+            public_stage.max_per_user
         }
+    }
+
+    #[view]
+    public fun public_stage_max_per_user(
+        collection: Object<Collection>,
+        index: u64,
+    ): u64 acquires PublicMintStageWithLimit, MintStageData, MintStage {
+        let (_, mint_stage_obj) = borrow_mint_stage(collection, index);
+        borrow_public_stage_with_limit(mint_stage_obj).max_per_user
+    }
+
+    #[view]
+    public fun allowlist_exists_with_index(collection: Object<Collection>, index: u64): bool acquires MintStageData {
+        let mint_stages = borrow(collection).mint_stages;
+        let mint_stage = *vector::borrow(&mint_stages, index);
+        allowlist_exists(mint_stage)
+    }
+
+    #[view]
+    public fun allowlist_exists(mint_stage: Object<MintStage>): bool {
+        exists<Allowlist>(object::object_address(&mint_stage))
+    }
+
+    #[view]
+    public fun public_stage_with_limit_exists_with_index(
+        collection: Object<Collection>,
+        index: u64,
+    ): bool acquires MintStageData {
+        let mint_stages = borrow(collection).mint_stages;
+        let mint_stage = *vector::borrow(&mint_stages, index);
+        public_stage_with_limit_exists(mint_stage)
+    }
+
+    #[view]
+    public fun public_stage_with_limit_exists(mint_stage: Object<MintStage>): bool {
+        exists<PublicMintStageWithLimit>(object::object_address(&mint_stage))
+    }
+
+    #[view]
+    public fun mint_stage_name(mint_stage: Object<MintStage>): String acquires MintStage {
+        borrow_mint_stage_from_object(mint_stage).name
+    }
+
+    #[view]
+    public fun mint_stage_start_time(mint_stage: Object<MintStage>): u64 acquires MintStage {
+        borrow_mint_stage_from_object(mint_stage).start_time
+    }
+
+    #[view]
+    public fun mint_stage_end_time(mint_stage: Object<MintStage>): u64 acquires MintStage {
+        borrow_mint_stage_from_object(mint_stage).end_time
+    }
+
+    #[view]
+    public fun find_mint_stage_index_by_name(
+        collection: Object<Collection>,
+        name: String,
+    ): u64 acquires MintStageData, MintStage {
+        let (is_found, index) = vector::find(&borrow(collection).mint_stages, |mint_stage| {
+            let mint_stage: &Object<MintStage> = mint_stage;
+            let mint_stage = borrow_mint_stage_from_object(*mint_stage);
+            mint_stage.name == name
+        });
+        assert!(is_found, error::not_found(ESTAGE_DOES_NOT_EXIST));
+        index
+    }
+
+    #[view]
+    public fun find_mint_stage_by_index(
+        collection: Object<Collection>,
+        index: u64,
+    ): Object<MintStage> acquires MintStageData {
+        *vector::borrow(&borrow(collection).mint_stages, index)
+    }
+
+    inline fun get_mint_stage(
+        mint_stages: &mut vector<Object<MintStage>>,
+        index: u64,
+    ): (&mut MintStage, Object<MintStage>) acquires MintStage {
+        let mint_stage_obj = *vector::borrow(mint_stages, index);
+        let mint_stage = borrow_mut_mint_stage_from_object(mint_stage_obj);
+        (mint_stage, mint_stage_obj)
+    }
+
+    inline fun borrow_mut_allowlist(mint_stage: Object<MintStage>): &mut Allowlist {
+        assert!(allowlist_exists(mint_stage), EALLOWLIST_DOES_NOT_EXIST);
+        borrow_global_mut<Allowlist>(object::object_address(&mint_stage))
+    }
+
+    inline fun borrow_allowlist(mint_stage: Object<MintStage>): &Allowlist {
+        freeze(borrow_mut_allowlist(mint_stage))
+    }
+
+    inline fun borrow_mut_public_stage_with_limit(mint_stage: Object<MintStage>): &mut PublicMintStageWithLimit {
+        assert!(public_stage_with_limit_exists(mint_stage), EPUBLIC_STAGE_WITH_LIMIT_DOES_NOT_EXIST);
+        borrow_global_mut<PublicMintStageWithLimit>(object::object_address(&mint_stage))
+    }
+
+    inline fun borrow_public_stage_with_limit(mint_stage: Object<MintStage>): &PublicMintStageWithLimit {
+        freeze(borrow_mut_public_stage_with_limit(mint_stage))
+    }
+
+    inline fun create_mint_stage_object(
+        collection_addr: address,
+        name: String,
+        start_time: u64,
+        end_time: u64,
+    ): Object<MintStage> {
+        let constructor_ref = &object::create_object(collection_addr);
+        move_to(&object::generate_signer(constructor_ref), MintStage {
+            name,
+            start_time,
+            end_time,
+            extend_ref: object::generate_extend_ref(constructor_ref),
+            delete_ref: object::generate_delete_ref(constructor_ref),
+        });
+        object::object_from_constructor_ref(constructor_ref)
+    }
+
+    inline fun mint_stage_signer(mint_stage: Object<MintStage>): signer acquires MintStage {
+        let mint_stage = borrow_mint_stage_from_object(mint_stage);
+        object::generate_signer_for_extending(&mint_stage.extend_ref)
     }
 
     /// This function adds the new stage based on the start and end time of the mint stage.
     /// The categories are sorted from the earliest start time to the latest.
-    inline fun add_to_stages(
-        stages: &mut vector<String>,
-        new_stage: String,
-        new_start_time: u64,
-        new_end_time: u64,
-        mint_stages: &SimpleMap<String, MintStage>,
-    ) {
-        let len = vector::length(stages);
+    fun add_to_stages(
+        mint_stages: &mut vector<Object<MintStage>>,
+        new_stage: Object<MintStage>,
+    ) acquires MintStage {
+        let len = vector::length(mint_stages);
         let index = 0;
 
         while (index < len) {
-            let current_stage = vector::borrow(stages, index);
-            let current_stage = simple_map::borrow(mint_stages, current_stage);
-            if (new_start_time < current_stage.start_time
-                || (new_start_time == current_stage.start_time && new_end_time < current_stage.end_time)) {
+            let current_stage = *vector::borrow(mint_stages, index);
+            let current_stage_start_time = mint_stage_start_time(current_stage);
+            let new_start_time = mint_stage_start_time(new_stage);
+            let new_end_time = mint_stage_end_time(new_stage);
+            if (new_start_time < current_stage_start_time
+                || (new_start_time == current_stage_start_time && new_end_time < mint_stage_end_time(current_stage))) {
                 break
             };
             index = index + 1;
         };
 
-        vector::insert(stages, index, new_stage);
+        vector::insert(mint_stages, index, new_stage);
     }
 
     inline fun allowlist_balance_internal(allowlist: &SmartTable<address, u64>, addr: address): u64 {
@@ -406,42 +596,54 @@ module minter::mint_stage {
         *smart_table::borrow(allowlist, addr)
     }
 
-    inline fun authorized_borrow_mut_mint_stage<T: key>(
+    inline fun authorized_borrow_mut_mint_stage(
         owner: &signer,
-        obj: Object<T>,
-        stage: String,
-    ): &mut MintStage acquires MintStageData {
-        let mint_stages = &mut authorized_borrow_mut(owner, obj).mint_stages;
-        assert!(simple_map::contains_key(mint_stages, &stage), error::not_found(ESTAGE_DOES_NOT_EXIST));
-        simple_map::borrow_mut(mint_stages, &stage)
+        collection: Object<Collection>,
+        index: u64,
+    ): (&mut MintStage, Object<MintStage>) acquires MintStageData {
+        let mint_stages = &mut authorized_borrow_mut(owner, collection).mint_stages;
+        get_mint_stage(mint_stages, index)
     }
 
-    inline fun authorized_borrow_mut<T: key>(owner: &signer, obj: Object<T>): &mut MintStageData {
-        assert_owner(owner, obj);
+    inline fun authorized_borrow_mut(owner: &signer, collection: Object<Collection>): &mut MintStageData {
+        assert_owner(owner, collection);
 
-        let obj_addr = object::object_address(&obj);
-        assert!(mint_stage_data_exists(obj_addr), error::not_found(EMINT_STAGE_DATA_DOES_NOT_EXIST));
-        borrow_global_mut(obj_addr)
+        assert!(mint_stage_data_exists(collection), error::not_found(EMINT_STAGE_DATA_DOES_NOT_EXIST));
+        borrow_global_mut<MintStageData>(object::object_address(&collection))
     }
 
-    inline fun borrow<T: key>(obj: Object<T>): &MintStageData {
-        freeze(borrow_mut(obj))
+    inline fun borrow(collection: Object<Collection>): &MintStageData {
+        freeze(borrow_mut(collection))
     }
 
-    inline fun borrow_mut<T: key>(obj: Object<T>): &mut MintStageData {
-        let obj_addr = object::object_address(&obj);
-        assert!(mint_stage_data_exists(obj_addr), error::not_found(EMINT_STAGE_DATA_DOES_NOT_EXIST));
-        borrow_global_mut<MintStageData>(obj_addr)
+    inline fun borrow_mut(collection: Object<Collection>): &mut MintStageData {
+        assert!(mint_stage_data_exists(collection), error::not_found(EMINT_STAGE_DATA_DOES_NOT_EXIST));
+        borrow_global_mut<MintStageData>(object::object_address(&collection))
     }
 
-    inline fun borrow_mut_mint_stage<T: key>(obj: Object<T>, stage: String): &mut MintStage acquires MintStageData {
-        let mint_stages = &mut borrow_mut(obj).mint_stages;
-        assert!(simple_map::contains_key(mint_stages, &stage), error::not_found(ESTAGE_DOES_NOT_EXIST));
-        simple_map::borrow_mut(mint_stages, &stage)
+    inline fun borrow_mut_mint_stage_from_object(mint_stage: Object<MintStage>): &mut MintStage {
+        let mint_stage_addr = object::object_address(&mint_stage);
+        assert!(exists<MintStage>(mint_stage_addr), EMINT_STAGE_DOES_NOT_EXIST);
+        borrow_global_mut<MintStage>(mint_stage_addr)
     }
 
-    inline fun borrow_mint_stage<T: key>(obj: Object<T>, stage: String): &MintStage acquires MintStageData {
-        borrow_mut_mint_stage(obj, stage)
+    inline fun borrow_mut_mint_stage(
+        collection: Object<Collection>,
+        index: u64,
+    ): (&mut MintStage, Object<MintStage>) acquires MintStageData {
+        let mint_stages = &mut borrow_mut(collection).mint_stages;
+        get_mint_stage(mint_stages, index)
+    }
+
+    inline fun borrow_mint_stage(
+        collection: Object<Collection>,
+        index: u64,
+    ): (&MintStage, Object<MintStage>) acquires MintStageData {
+        borrow_mut_mint_stage(collection, index)
+    }
+
+    inline fun borrow_mint_stage_from_object(mint_stage: Object<MintStage>): &MintStage {
+        borrow_mut_mint_stage_from_object(mint_stage)
     }
 
     inline fun valid_start_and_end_time(start_time: u64, end_time: u64) {
@@ -449,7 +651,7 @@ module minter::mint_stage {
         assert!(end_time > timestamp::now_seconds(), error::invalid_argument(EINVALID_END_TIME));
     }
 
-    inline fun assert_owner<T: key>(owner: &signer, obj: Object<T>) {
-        assert!(object::is_owner(obj, signer::address_of(owner)), error::unauthenticated(ENOT_OWNER));
+    inline fun assert_owner(owner: &signer, collection: Object<Collection>) {
+        assert!(object::owner(collection) == signer::address_of(owner), error::unauthenticated(ENOT_OWNER));
     }
 }

--- a/token-minter/tests/modules/mint_stage_tests.move
+++ b/token-minter/tests/modules/mint_stage_tests.move
@@ -1,7 +1,5 @@
 #[test_only]
 module minter::mint_stage_tests {
-    use std::option;
-    use std::option::Option;
     use std::signer;
     use std::string::{String, utf8};
     use std::vector;
@@ -9,8 +7,11 @@ module minter::mint_stage_tests {
     use aptos_framework::object::{ConstructorRef, Object};
     use aptos_framework::timestamp;
 
+    use aptos_token_objects::collection::Collection;
+
+    use minter::collection_components;
+    use minter::collection_utils;
     use minter::mint_stage;
-    use minter::mint_stage::MintStageData;
 
     fun init_timestamp(aptos_framework: &signer, timestamp_seconds: u64) {
         timestamp::set_time_has_started_for_testing(aptos_framework);
@@ -24,21 +25,23 @@ module minter::mint_stage_tests {
         let start_time = timestamp::now_seconds() - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
-        assert!(mint_stage::start_time(mint_stage_data, category) == start_time, 0);
-        assert!(mint_stage::end_time(mint_stage_data, category) == end_time, 0);
-        assert!(vector::length(&mint_stage::stages(mint_stage_data)) == 1, 0);
-        assert!(*vector::borrow(&mint_stage::stages(mint_stage_data), 0) == category, 0);
-        assert!(mint_stage::is_active(mint_stage_data, category) == true, 0);
+        assert!(mint_stage::start_time(collection, index) == start_time, 0);
+        assert!(mint_stage::end_time(collection, index) == end_time, 0);
+        assert!(vector::length(&mint_stage::stages(collection)) == 1, 0);
+        assert!(*vector::borrow(&mint_stage::stages(collection), 0) == category, 0);
+        assert!(mint_stage::is_active(collection, index) == true, 0);
         // Assert there is no allowlist configured yet - meaning anyone can mint
-        assert!(!mint_stage::is_allowlisted(mint_stage_data, category, signer::address_of(creator)), 0);
+        let mint_stage = mint_stage::find_mint_stage_by_index(collection, 0);
+        assert!(!mint_stage::allowlist_exists(mint_stage), 0);
     }
 
     #[test(creator = @0x123, aptos_framework = @0x1)]
@@ -50,7 +53,7 @@ module minter::mint_stage_tests {
         let start_time = timestamp::now_seconds() + 3600; // 1 hour post now
         let end_time = start_time - 7200; // 2 hours prior to now
         let category = utf8(b"Public sale");
-        create_mint_stage_data_object(creator, start_time, end_time, category, option::none());
+        create_mint_stage_data_object(creator, start_time, end_time, category, 0);
     }
 
     #[test(creator = @0x123, aptos_framework = @0x1)]
@@ -62,7 +65,7 @@ module minter::mint_stage_tests {
         let start_time = now - 10800 ; // 3 hours prior to now
         let end_time = now - 7200; // 2 hours prior to now
         let category = utf8(b"Public sale");
-        create_mint_stage_data_object(creator, start_time, end_time, category, option::none());
+        create_mint_stage_data_object(creator, start_time, end_time, category, 0);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -73,25 +76,46 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
         let user_addr = signer::address_of(user);
         let amount = 1;
-        mint_stage::add_to_allowlist(creator, mint_stage_data, category, user_addr, amount);
-        assert!(mint_stage::is_allowlisted(mint_stage_data, category, user_addr) == true, 0);
+        mint_stage::add_to_allowlist(creator, collection, index, user_addr, amount);
+        assert!(mint_stage::is_allowlisted(collection, index, user_addr) == true, 0);
         // Assert stage has allowlist configured
-        assert!(mint_stage::is_stage_allowlisted(mint_stage_data, category), 0);
-        assert!(mint_stage::allowlist_balance(mint_stage_data, category, user_addr) == amount, 0);
+        assert!(mint_stage::is_stage_allowlisted(collection, index), 0);
+        assert!(mint_stage::allowlist_balance(collection, index, user_addr) == amount, 0);
 
         // User mints 1 token
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, amount);
-        assert!(mint_stage::allowlist_balance(mint_stage_data, category, user_addr) == 0, 0);
+        mint_stage::assert_active_and_execute(user, collection, index, amount);
+        assert!(mint_stage::allowlist_balance(collection, index, user_addr) == 0, 0);
+    }
+
+    #[test(creator = @0x123, aptos_framework = @0x1)]
+    fun test_remove_stage(creator: &signer, aptos_framework: &signer) {
+        let now = 100000;
+        init_timestamp(aptos_framework, now);
+        let presale = utf8(b"Presale");
+        let presale_start_time = now + 3600; // Starts 2 hours from now
+        let presale_end_time = presale_start_time + 3600; // Ends 3 hours from now
+        let (_, collection) = create_mint_stage_data_object(
+            creator,
+            presale_start_time,
+            presale_end_time,
+            presale,
+            0,
+        );
+        let presale_index = mint_stage::find_mint_stage_index_by_name(collection, presale);
+        mint_stage::remove_stage(creator, collection, presale_index);
+
+        assert!(vector::is_empty(&mint_stage::stages(collection)), 0);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -103,8 +127,15 @@ module minter::mint_stage_tests {
         let start_time = timestamp::now_seconds() + 3600;
         let end_time = start_time + 7200;
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(creator, start_time, end_time, category, option::none());
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 0);
+        let (_, collection) = create_mint_stage_data_object(
+            creator,
+            start_time,
+            end_time,
+            category,
+            0,
+        );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
+        mint_stage::assert_active_and_execute(user, collection, index, 0);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -116,18 +147,19 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
         // Need to set allowlist before executing, empty allowlist means anyone can mint.
-        mint_stage::add_to_allowlist(creator, mint_stage_data, category, signer::address_of(creator), 1);
+        mint_stage::add_to_allowlist(creator, collection, index, signer::address_of(creator), 1);
 
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 1);
+        mint_stage::assert_active_and_execute(user, collection, index, 1);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -139,16 +171,16 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
-
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
         // User tries calling instead of creator, this should fail.
-        mint_stage::add_to_allowlist(user, mint_stage_data, category, signer::address_of(creator), 1);
+        mint_stage::add_to_allowlist(user, collection, index, signer::address_of(creator), 1);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -159,20 +191,21 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
         let user_addr = signer::address_of(user);
         let amount = 1;
-        mint_stage::add_to_allowlist(creator, mint_stage_data, category, user_addr, amount);
-        mint_stage::remove_from_allowlist(creator, mint_stage_data, category, user_addr);
+        mint_stage::add_to_allowlist(creator, collection, index, user_addr, amount);
+        mint_stage::remove_from_allowlist(creator, collection, index, user_addr);
 
-        assert!(mint_stage::is_allowlisted(mint_stage_data, category, user_addr) == false, 0);
+        assert!(mint_stage::is_allowlisted(collection, index, user_addr) == false, 0);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -183,25 +216,26 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
         let user_addr = signer::address_of(user);
         let creator_addr = signer::address_of(creator);
         let amount = 1;
-        mint_stage::add_to_allowlist(creator, mint_stage_data, category, user_addr, amount);
-        mint_stage::add_to_allowlist(creator, mint_stage_data, category, creator_addr, amount);
-        mint_stage::remove_everyone_from_allowlist(creator, mint_stage_data, category);
+        mint_stage::add_to_allowlist(creator, collection, index, user_addr, amount);
+        mint_stage::add_to_allowlist(creator, collection, index, creator_addr, amount);
+        mint_stage::clear_allowlist(creator, collection, index);
 
         // Assert no one is allowlisted
-        assert!(!mint_stage::is_allowlisted(mint_stage_data, category, user_addr), 0);
-        assert!(!mint_stage::is_allowlisted(mint_stage_data, category, creator_addr), 0);
-        assert!(mint_stage::allowlist_count(mint_stage_data, category) == 0, 0);
+        assert!(!mint_stage::is_allowlisted(collection, index, user_addr), 0);
+        assert!(!mint_stage::is_allowlisted(collection, index, creator_addr), 0);
+        assert!(mint_stage::allowlist_count(collection, index) == 0, 0);
     }
 
     #[test(creator = @0x123, aptos_framework = @0x1)]
@@ -212,20 +246,21 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
         let new_start_time = now - 7200; // 2 hours prior to now
         let new_end_time = now + 3600; // 1 hour post now
-        mint_stage::set_start_and_end_time(creator, mint_stage_data, category, new_start_time, new_end_time);
+        mint_stage::set_start_and_end_time(creator, collection, index, new_start_time, new_end_time);
 
-        assert!(mint_stage::start_time(mint_stage_data, category) == new_start_time, 0);
-        assert!(mint_stage::end_time(mint_stage_data, category) == new_end_time, 0);
+        assert!(mint_stage::start_time(collection, index) == new_start_time, 0);
+        assert!(mint_stage::end_time(collection, index) == new_end_time, 0);
     }
 
     #[test(creator = @0x123, aptos_framework = @0x1)]
@@ -236,23 +271,24 @@ module minter::mint_stage_tests {
         let start_time = timestamp::now_seconds() + 3600; // 1 hour post now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
-        assert!(mint_stage::is_active(mint_stage_data, category) == false, 0);
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
+        assert!(mint_stage::is_active(collection, index) == false, 0);
 
         let new_start_time = now - 3600; // Change start time to 1 hour prior to now
         let new_end_time = now + 3600; // Change end time to 1 hour post now
-        mint_stage::set_start_and_end_time(creator, mint_stage_data, category, new_start_time, new_end_time);
-        assert!(mint_stage::is_active(mint_stage_data, category) == true, 0);
+        mint_stage::set_start_and_end_time(creator, collection, index, new_start_time, new_end_time);
+        assert!(mint_stage::is_active(collection, index) == true, 0);
 
         let new_end_time = timestamp::now_seconds() + 3600; // Change end time to 1 hour post now
-        mint_stage::set_start_and_end_time(creator, mint_stage_data, category, new_start_time, new_end_time);
-        assert!(mint_stage::is_active(mint_stage_data, category) == true, 0);
+        mint_stage::set_start_and_end_time(creator, collection, index, new_start_time, new_end_time);
+        assert!(mint_stage::is_active(collection, index) == true, 0);
     }
 
     #[test(creator = @0x123, aptos_framework = @0x1)]
@@ -283,12 +319,13 @@ module minter::mint_stage_tests {
             private_sale_start_time,
             private_sale_end_time,
             private_sale,
-            option::none(),
+            0,
         );
-        mint_stage::create(&object_signer, presale_start_time, presale_end_time, presale, option::none());
-        mint_stage::create(&object_signer, public_sale_start_time, public_sale_end_time, public_sale, option::none());
+        let collection = object::convert(mint_stage_data);
+        mint_stage::create(&object_signer, presale, presale_start_time, presale_end_time);
+        mint_stage::create(&object_signer, public_sale, public_sale_start_time, public_sale_end_time);
 
-        let sorted_categories = mint_stage::stages(mint_stage_data);
+        let sorted_categories = mint_stage::stages(collection);
 
         // Order should be (Private Sale, Presale, Public Sale)
         assert!(*vector::borrow(&sorted_categories, 0) == private_sale, 0); // Private Sale ends first
@@ -304,19 +341,19 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
-        assert!(mint_stage::mint_stage_data_exists(object::object_address(&mint_stage_data)), 0);
+        assert!(mint_stage::mint_stage_data_exists(collection), 0);
 
-        mint_stage::destroy(creator, mint_stage_data);
+        mint_stage::destroy(creator, collection);
 
         // Assert `MintStageData` resource has been destroyed.
-        assert!(!mint_stage::mint_stage_data_exists(object::object_address(&mint_stage_data)), 0);
+        assert!(!mint_stage::mint_stage_data_exists(collection), 0);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -333,39 +370,46 @@ module minter::mint_stage_tests {
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let collection = object::convert(mint_stage_data);
 
-        mint_stage::destroy(user, mint_stage_data);
+        mint_stage::destroy(user, collection);
     }
 
     // =========================== NoAllowlist Tests =========================== //
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
-    fun test_no_allowlist_execution(creator: &signer, user: &signer, aptos_framework: &signer) {
+    fun test_public_sale_with_limit_execution(creator: &signer, user: &signer, aptos_framework: &signer) {
         let now = 100000;
         init_timestamp(aptos_framework, now);
 
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let max_per_user = option::some(3);
-        let (_, mint_stage_data) = create_mint_stage_data_object(creator, start_time, end_time, category, max_per_user);
+        let max_per_user = 3;
+        let (_, collection) = create_mint_stage_data_object(creator, start_time, end_time, category, max_per_user);
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
 
         let user_addr = signer::address_of(user);
         let amount = 1;
         // Assert no_allowlist is configured with max per user limit
-        assert!(mint_stage::no_allowlist_max_per_user(mint_stage_data, category) == max_per_user, 0);
+        assert!(mint_stage::public_stage_max_per_user(collection, index) == max_per_user, 0);
         // User has not minted yet, so their no allowlist user balance should be `max_per_user`
-        assert!(mint_stage::user_balance_in_no_allowlist(mint_stage_data, category, user_addr) == max_per_user, 0);
+        assert!(
+            mint_stage::public_stage_with_limit_user_balance(collection, index, user_addr) == max_per_user,
+            0,
+        );
 
         // User tries to mint 1 token, should be successful
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, amount);
+        mint_stage::assert_active_and_execute(user, collection, index, amount);
         // Verify user balance in no_allowlist is updated to (max per user - amount minted)
         assert!(
-            mint_stage::user_balance_in_no_allowlist(mint_stage_data, category, user_addr) == option::some(
-                *option::borrow(&max_per_user) - amount
-            ),
+            mint_stage::public_stage_with_limit_user_balance(
+                collection,
+                index,
+                user_addr
+            ) == max_per_user - amount,
             0,
         );
     }
@@ -379,13 +423,14 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let max_per_user = option::some(1);
-        let (_, mint_stage_data) = create_mint_stage_data_object(creator, start_time, end_time, category, max_per_user);
+        let max_per_user = 1;
+        let (_, collection) = create_mint_stage_data_object(creator, start_time, end_time, category, max_per_user);
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
         // User tries to mint 1 token, should be successful
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 1);
+        mint_stage::assert_active_and_execute(user, collection, index, 1);
 
         // User tries to mint 1 more token, should fail since they have reached the max limit
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 1);
+        mint_stage::assert_active_and_execute(user, collection, index, 1);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -400,18 +445,19 @@ module minter::mint_stage_tests {
         let start_time = now - 3600; // 1 hour prior to now
         let end_time = start_time + 7200; // 2 hours post now
         let category = utf8(b"Public sale");
-        let (_, mint_stage_data) = create_mint_stage_data_object(
+        let (_, collection) = create_mint_stage_data_object(
             creator,
             start_time,
             end_time,
             category,
-            option::none() // no max_per_user set
+            0, // No public sale with limit set
         );
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
         // Perform minting without restrictions
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 1);
+        mint_stage::assert_active_and_execute(user, collection, index, 1);
 
         // Allow user to mint again since no max_per_user is set
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 1);
+        mint_stage::assert_active_and_execute(user, collection, index, 1);
     }
 
     #[test(creator = @0x123, user = @0x456, aptos_framework = @0x1)]
@@ -429,20 +475,22 @@ module minter::mint_stage_tests {
             start_time,
             end_time,
             category,
-            option::none()
+            0,
         );
+        let collection = object::convert(mint_stage_data);
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
         // Perform minting without restrictions
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 1);
+        mint_stage::assert_active_and_execute(user, collection, index, 1);
 
-        let new_max_per_user = option::some(1); // Update to 1
-        mint_stage::set_no_allowlist_max_per_user(
+        let new_max_per_user = 1; // Update to 1
+        mint_stage::set_public_stage_max_per_user(
             creator,
-            mint_stage_data,
-            category,
+            collection,
+            index,
             new_max_per_user
         );
         // User tries to mint more than new `max_per_user`, should fail
-        mint_stage::assert_active_and_execute(user, mint_stage_data, category, 2);
+        mint_stage::assert_active_and_execute(user, collection, index, 2);
     }
 
     fun create_mint_stage_data_object(
@@ -450,17 +498,22 @@ module minter::mint_stage_tests {
         start_time: u64,
         end_time: u64,
         category: String,
-        no_allowlist_max_per_user: Option<u64>,
-    ): (signer, Object<MintStageData>) {
-        let constructor_ref = create_object(creator);
+        public_stage_max_per_user: u64, // 0 means no public stage should be created
+    ): (signer, Object<Collection>) {
+        let constructor_ref = collection_utils::create_unlimited_collection(creator);
+        collection_components::create_refs_and_properties(&constructor_ref);
         let mint_stage_data = mint_stage::init(
             &constructor_ref,
+            category,
             start_time,
             end_time,
-            category,
-            no_allowlist_max_per_user,
         );
-        (object::generate_signer(&constructor_ref), mint_stage_data)
+        let collection = object::convert(mint_stage_data);
+        let index = mint_stage::find_mint_stage_index_by_name(collection, category);
+        if (public_stage_max_per_user > 0) {
+            mint_stage::set_public_stage_max_per_user(creator, collection, index, public_stage_max_per_user);
+        };
+        (object::generate_signer(&constructor_ref), collection)
     }
 
     fun create_object(creator: &signer): ConstructorRef {


### PR DESCRIPTION
## Description
- Refactor mint stage to use vector vs simple map
- Refactor create method to not take in `no_allowlist_max_per_user` as this is confusing when first initially creating mint stages.

