### PR TITLE
use "image" field to comply with erc721

### DIFF
--- a/ez-launch/src/cli/assetUploader.ts
+++ b/ez-launch/src/cli/assetUploader.ts
@@ -189,7 +189,7 @@ const updateImageField = (jsonFilePath: string, mediaUrl: string): void => {
       );
     }
 
-    metadataJson.uri = mediaUrl;
+    metadataJson.image = mediaUrl;
     fs.writeFileSync(jsonFilePath, JSON.stringify(metadataJson, null, 4));
   } catch (error) {
     throw new Error(

--- a/ez-launch/src/cli/cli.ts
+++ b/ez-launch/src/cli/cli.ts
@@ -211,7 +211,7 @@ async function validateProjectConfig(projectPath: string) {
     errors.push("Collection name cannot be empty.");
   }
 
-  if (!config.collection.uri) {
+  if (!config.collection.image) {
     errors.push("Collection URI cannot be empty.");
   }
 
@@ -352,7 +352,7 @@ async function createCollection(
     collection: {
       name: collectionMetadata.name,
       description: collectionMetadata.description,
-      uri: collectionMetadata.uri,
+      uri: collectionMetadata.image,
       mutableCollectionMetadata: responses.mutableCollectionMetadata,
       mutableTokenMetadata: responses.mutableTokenMetadata,
       randomMint: responses.randomMint,
@@ -382,9 +382,9 @@ async function createCollection(
     const tokenMetadata = JSON.parse(fs.readFileSync(filePath, "utf8"));
 
     // Ensure that `uri` exists in tokenMetadata and use it directly
-    if (!tokenMetadata.uri) {
+    if (!tokenMetadata.image) {
       console.warn(
-        `URI missing in token metadata for ${path.basename(filePath)}. Skipping.`,
+        `Image missing in token metadata for ${path.basename(filePath)}. Skipping.`,
       );
       return;
     }
@@ -392,7 +392,7 @@ async function createCollection(
     const token: TokenMetadata = {
       name: tokenMetadata.name,
       description: tokenMetadata.description,
-      uri: tokenMetadata.uri,
+      uri: tokenMetadata.image,
     };
 
     outJson.tokens.push(token);
@@ -406,7 +406,7 @@ async function createCollection(
       creator: account,
       description: collectionMetadata.description,
       name: collectionMetadata.name,
-      uri: collectionMetadata.uri,
+      uri: collectionMetadata.image,
       mutableCollectionMetadata: responses.mutableCollectionMetadata,
       mutableTokenMetadata: responses.mutableTokenMetadata,
       randomMint: responses.randomMint,


### PR DESCRIPTION
erc721 uses image field, we should do the same: https://docs.opensea.io/docs/metadata-standards.

example run: 
```
jillxu@Jills-MBP cli % ts-node cli.ts upload --profile=default --asset-path="/Users/jillxu/Documents/GitHub/token-minter/ez-launch/src/examples" --fund-amount=0.01
Collection Metadata JSON URI: https://arweave.net/yHs1YmUM5pyS4i9_21iNTFpE8C9395JKQtavzcdfAoc
Token Metadata JSON Folder URI: https://arweave.net/cLApcuIqbt9vY4FNwxB3fntjJSgd6ToEEEbkHtDZlZc
Assets successfully uploaded.
```